### PR TITLE
Add subtle dark mode with toggle functionality

### DIFF
--- a/app/assets/stylesheets/application.css
+++ b/app/assets/stylesheets/application.css
@@ -8,3 +8,185 @@
  *
  * Consider organizing styles into separate files for maintainability.
  */
+
+/* Theme transitions */
+.transition-theme {
+  transition-property: background-color, border-color, color, fill, stroke;
+  transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+  transition-duration: 150ms;
+}
+
+/* Force class-based dark mode with subtle colors */
+.dark .dark\:bg-gray-700 {
+  background-color: rgb(229 231 235); /* gray-200 */
+}
+
+.dark .dark\:bg-gray-800 {
+  background-color: rgb(243 244 246); /* gray-100 */
+}
+
+.dark .dark\:bg-gray-900 {
+  background-color: rgb(249 250 251); /* gray-50 */
+}
+
+/* Override body background for dark mode - subtle gray */
+.dark {
+  background-color: rgb(249 250 251) !important; /* gray-50 */
+  color: rgb(31 41 55) !important; /* gray-800 */
+}
+
+.dark .dark\:text-white {
+  color: rgb(17 24 39); /* gray-900 */
+}
+
+.dark .dark\:text-gray-300 {
+  color: rgb(75 85 99); /* gray-600 */
+}
+
+.dark .dark\:text-gray-400 {
+  color: rgb(107 114 128); /* gray-500 */
+}
+
+.dark .dark\:border-gray-600 {
+  border-color: rgb(229 231 235); /* gray-200 */
+}
+
+.dark .dark\:border-gray-700 {
+  border-color: rgb(209 213 219); /* gray-300 */
+}
+
+.dark .dark\:hover\:bg-gray-600:hover {
+  background-color: rgb(229 231 235); /* gray-200 */
+}
+
+.dark .dark\:hover\:bg-gray-700:hover {
+  background-color: rgb(243 244 246); /* gray-100 */
+}
+
+.dark .dark\:hover\:text-white:hover {
+  color: rgb(17 24 39); /* gray-900 */
+}
+
+/* Keep accent colors vibrant */
+.dark .dark\:bg-indigo-500 {
+  background-color: rgb(99 102 241);
+}
+
+.dark .dark\:hover\:bg-indigo-600:hover {
+  background-color: rgb(79 70 229);
+}
+
+.dark .dark\:text-indigo-400 {
+  color: rgb(99 102 241); /* Keep indigo bright */
+}
+
+.dark .dark\:hover\:text-indigo-300:hover {
+  color: rgb(79 70 229);
+}
+
+.dark .dark\:text-red-400 {
+  color: rgb(239 68 68); /* red-500 */
+}
+
+.dark .dark\:hover\:text-red-300:hover {
+  color: rgb(220 38 38); /* red-600 */
+}
+
+.dark .dark\:text-green-400 {
+  color: rgb(34 197 94); /* green-500 */
+}
+
+.dark .dark\:bg-red-900\/20 {
+  background-color: rgb(254 226 226); /* red-100 */
+}
+
+.dark .dark\:text-red-200 {
+  color: rgb(220 38 38); /* red-600 */
+}
+
+.dark .dark\:text-red-300 {
+  color: rgb(239 68 68); /* red-500 */
+}
+
+.dark .dark\:text-green-200 {
+  color: rgb(34 197 94); /* green-500 */
+}
+
+.dark .dark\:bg-green-900 {
+  background-color: rgb(220 252 231); /* green-100 */
+}
+
+.dark .dark\:bg-red-900 {
+  background-color: rgb(254 226 226); /* red-100 */
+}
+
+.dark .dark\:border-green-600 {
+  border-color: rgb(134 239 172); /* green-300 */
+}
+
+.dark .dark\:border-red-600 {
+  border-color: rgb(252 165 165); /* red-300 */
+}
+
+.dark .dark\:bg-opacity-90 {
+  background-color: rgb(249 250 251 / 0.9);
+}
+
+.dark .dark\:focus\:ring-offset-gray-800:focus {
+  --tw-ring-offset-color: rgb(243 244 246); /* gray-100 */
+}
+
+.dark .dark\:divide-gray-700 > * + * {
+  border-color: rgb(229 231 235); /* gray-200 */
+}
+
+.dark .dark\:ring-gray-700 {
+  --tw-ring-color: rgb(209 213 219); /* gray-300 */
+}
+
+/* Additional dark mode overrides for subtle theme */
+.dark body {
+  background-color: rgb(249 250 251) !important; /* gray-50 */
+}
+
+.dark .bg-white {
+  background-color: rgb(255 255 255) !important; /* Keep white */
+}
+
+.dark .text-gray-900 {
+  color: rgb(17 24 39) !important; /* gray-900 */
+}
+
+.dark .text-gray-700 {
+  color: rgb(55 65 81) !important; /* gray-700 */
+}
+
+.dark .text-gray-500 {
+  color: rgb(107 114 128) !important; /* gray-500 */
+}
+
+.dark .border-gray-300 {
+  border-color: rgb(209 213 219) !important; /* gray-300 */
+}
+
+.dark .border-gray-200 {
+  border-color: rgb(229 231 235) !important; /* gray-200 */
+}
+
+.dark input,
+.dark select,
+.dark textarea {
+  background-color: rgb(249 250 251) !important; /* gray-50 */
+  color: rgb(17 24 39) !important; /* gray-900 */
+  border-color: rgb(209 213 219) !important; /* gray-300 */
+}
+
+.dark .shadow {
+  box-shadow: 0 1px 3px 0 rgba(0, 0, 0, 0.1), 0 1px 2px 0 rgba(0, 0, 0, 0.06) !important;
+}
+
+/* Navigation bar in dark mode */
+.dark nav {
+  background-color: rgb(243 244 246) !important; /* gray-100 */
+  border-bottom-color: rgb(229 231 235) !important; /* gray-200 */
+}

--- a/app/assets/tailwind/application.css
+++ b/app/assets/tailwind/application.css
@@ -1,1 +1,21 @@
 @import "tailwindcss";
+
+/* Enable dark mode with class strategy */
+@media (prefers-color-scheme: dark) {
+  :root {
+    color-scheme: dark;
+  }
+}
+
+.dark {
+  color-scheme: dark;
+}
+
+/* Custom dark mode utilities if needed */
+@layer utilities {
+  .transition-theme {
+    transition-property: background-color, border-color, color, fill, stroke;
+    transition-timing-function: cubic-bezier(0.4, 0, 0.2, 1);
+    transition-duration: 150ms;
+  }
+}

--- a/app/javascript/controllers/theme_controller.js
+++ b/app/javascript/controllers/theme_controller.js
@@ -1,0 +1,64 @@
+import { Controller } from "@hotwired/stimulus"
+
+export default class extends Controller {
+  static targets = [ "icon" ]
+  
+  connect() {
+    // Check for saved theme preference or default to 'light'
+    const theme = localStorage.getItem('theme') || 'light'
+    
+    // Check system preference if no saved preference
+    if (!localStorage.getItem('theme')) {
+      const systemPrefersDark = window.matchMedia('(prefers-color-scheme: dark)').matches
+      if (systemPrefersDark) {
+        this.setTheme('dark')
+      } else {
+        this.setTheme('light')
+      }
+    } else {
+      this.setTheme(theme)
+    }
+    
+    // Listen for system theme changes
+    window.matchMedia('(prefers-color-scheme: dark)').addEventListener('change', (e) => {
+      if (!localStorage.getItem('theme')) {
+        this.setTheme(e.matches ? 'dark' : 'light')
+      }
+    })
+  }
+  
+  toggle() {
+    const currentTheme = document.documentElement.classList.contains('dark') ? 'dark' : 'light'
+    const newTheme = currentTheme === 'dark' ? 'light' : 'dark'
+    this.setTheme(newTheme)
+  }
+  
+  setTheme(theme) {
+    if (theme === 'dark') {
+      document.documentElement.classList.add('dark')
+    } else {
+      document.documentElement.classList.remove('dark')
+    }
+    
+    // Save preference
+    localStorage.setItem('theme', theme)
+    
+    // Update icon
+    this.updateIcon(theme)
+    
+    // Dispatch custom event
+    window.dispatchEvent(new CustomEvent('theme-changed', { detail: { theme } }))
+  }
+  
+  updateIcon(theme) {
+    if (!this.hasIconTarget) return
+    
+    if (theme === 'dark') {
+      // Show sun icon when in dark mode (to switch to light)
+      this.iconTarget.innerHTML = `<path fill-rule="evenodd" d="M10 2a1 1 0 011 1v1a1 1 0 11-2 0V3a1 1 0 011-1zm4 8a4 4 0 11-8 0 4 4 0 018 0zm-.464 4.95l.707.707a1 1 0 001.414-1.414l-.707-.707a1 1 0 00-1.414 1.414zm2.12-10.607a1 1 0 010 1.414l-.706.707a1 1 0 11-1.414-1.414l.707-.707a1 1 0 011.414 0zM17 11a1 1 0 100-2h-1a1 1 0 100 2h1zm-7 4a1 1 0 011 1v1a1 1 0 11-2 0v-1a1 1 0 011-1zM5.05 6.464A1 1 0 106.465 5.05l-.708-.707a1 1 0 00-1.414 1.414l.707.707zm1.414 8.486l-.707.707a1 1 0 01-1.414-1.414l.707-.707a1 1 0 011.414 1.414zM4 11a1 1 0 100-2H3a1 1 0 000 2h1z" clip-rule="evenodd"></path>`
+    } else {
+      // Show moon icon when in light mode (to switch to dark)
+      this.iconTarget.innerHTML = `<path d="M17.293 13.293A8 8 0 016.707 2.707a8.001 8.001 0 1010.586 10.586z"></path>`
+    }
+  }
+}

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -1,17 +1,17 @@
 <%= form_with(model: category, local: false) do |form| %>
   <% if category.errors.any? %>
-    <div class="rounded-md bg-red-50 p-4 mb-4">
+    <div class="rounded-md bg-red-50 dark:bg-red-900/20 p-4 mb-4">
       <div class="flex">
         <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <svg class="h-5 w-5 text-red-400 dark:text-red-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
           </svg>
         </div>
         <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">
+          <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
             There were <%= pluralize(category.errors.count, "error") %> with your submission
           </h3>
-          <div class="mt-2 text-sm text-red-700">
+          <div class="mt-2 text-sm text-red-700 dark:text-red-300">
             <ul class="list-disc pl-5 space-y-1">
               <% category.errors.full_messages.each do |message| %>
                 <li><%= message %></li>
@@ -25,46 +25,46 @@
 
   <div class="space-y-6">
     <div>
-      <%= form.label :name, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.label :name, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="mt-1">
         <%= form.text_field :name, 
-            class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+            class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
             placeholder: "e.g. Food, Transport, Salary" %>
       </div>
     </div>
 
     <div>
-      <%= form.label :color, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.label :color, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="mt-1">
         <div class="flex items-center space-x-3">
           <%= form.color_field :color, 
-              class: "h-10 w-20 rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
+              class: "h-10 w-20 rounded-md border-gray-300 dark:border-gray-600 shadow-sm focus:border-indigo-500 focus:ring-indigo-500",
               data: { 
                 controller: "color-picker",
                 action: "change->color-picker#updatePreview"
               } %>
           <div class="flex-1">
             <%= form.text_field :color, 
-                class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                 placeholder: "#FF5733",
                 data: { 
                   color_picker_target: "hexInput",
                   action: "input->color-picker#updateColor"
                 } %>
           </div>
-          <div class="h-10 w-10 rounded-md border border-gray-300" 
+          <div class="h-10 w-10 rounded-md border border-gray-300 dark:border-gray-600" 
                data-color-picker-target="preview"
                style="background-color: <%= category.color || '#6B7280' %>"></div>
         </div>
       </div>
-      <p class="mt-2 text-sm text-gray-500">Choose a color to identify this category</p>
+      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Choose a color to identify this category</p>
     </div>
   </div>
 
   <div class="mt-6 flex items-center justify-end space-x-3">
     <%= link_to "Cancel", categories_path, 
-        class: "rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2",
+        class: "rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 py-2 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800",
         data: { controller: "modal", action: "click->modal#close" } %>
-    <%= form.submit class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
+    <%= form.submit class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800" %>
   </div>
 <% end %>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -1,13 +1,13 @@
 <%= turbo_frame_tag "modal" do %>
   <div class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-90 transition-opacity" 
            data-action="click->modal#close"></div>
 
-      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+      <div class="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-lg font-medium leading-6 text-gray-900" id="modal-title">
+            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
               Edit Category
             </h3>
             <div class="mt-6">

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,8 +3,8 @@
     <%= turbo_frame_tag "categories" do %>
       <div class="sm:flex sm:items-center">
         <div class="sm:flex-auto">
-          <h1 class="text-3xl font-semibold text-gray-900">Categories</h1>
-          <p class="mt-2 text-sm text-gray-700">
+          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Categories</h1>
+          <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
             Manage your transaction categories
           </p>
         </div>
@@ -18,17 +18,17 @@
       <div class="mt-8 flow-root">
         <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
           <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-            <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-300">
-                <thead class="bg-gray-50">
+            <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 dark:ring-gray-700 md:rounded-lg">
+              <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
+                <thead class="bg-gray-50 dark:bg-gray-800">
                   <tr>
-                    <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                    <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white sm:pl-6">
                       Name
                     </th>
-                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
                       Color
                     </th>
-                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
                       Transactions
                     </th>
                     <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
@@ -36,29 +36,29 @@
                     </th>
                   </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-200 bg-white">
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
                   <% @categories.each do |category| %>
                     <%= turbo_frame_tag dom_id(category) do %>
                       <tr>
-                        <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 sm:pl-6">
+                        <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm font-medium text-gray-900 dark:text-white sm:pl-6">
                           <%= category.name %>
                         </td>
-                        <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                        <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
                           <div class="flex items-center">
-                            <div class="h-6 w-6 rounded-full border border-gray-300" 
+                            <div class="h-6 w-6 rounded-full border border-gray-300 dark:border-gray-600" 
                                  style="background-color: <%= category.color %>"></div>
-                            <span class="ml-2 text-xs text-gray-500"><%= category.color %></span>
+                            <span class="ml-2 text-xs text-gray-500 dark:text-gray-400"><%= category.color %></span>
                           </div>
                         </td>
-                        <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                        <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
                           <%= category.transactions.count %>
                         </td>
                         <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                           <%= link_to "Edit", edit_category_path(category), 
-                              class: "text-indigo-600 hover:text-indigo-900",
+                              class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300",
                               data: { turbo_frame: "modal" } %>
                           <%= link_to "Delete", category_path(category), 
-                              class: "ml-4 text-red-600 hover:text-red-900",
+                              class: "ml-4 text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300",
                               data: { 
                                 turbo_method: :delete,
                                 turbo_confirm: "Are you sure?"

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -1,13 +1,13 @@
 <%= turbo_frame_tag "modal" do %>
   <div class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-90 transition-opacity" 
            data-action="click->modal#close"></div>
 
-      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
+      <div class="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-lg font-medium leading-6 text-gray-900" id="modal-title">
+            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
               New Category
             </h3>
             <div class="mt-6">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html>
+<html data-controller="theme">
   <head>
     <title><%= content_for(:title) || "Finance App" %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -7,6 +7,16 @@
     <meta name="mobile-web-app-capable" content="yes">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
+    
+    <script>
+      // Apply theme immediately to prevent flash
+      (function() {
+        const theme = localStorage.getItem('theme') || 'light';
+        if (theme === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+      })();
+    </script>
 
     <%= yield :head %>
 
@@ -22,22 +32,62 @@
     <%= javascript_importmap_tags %>
   </head>
 
-  <body>
-    <div id="flash" class="fixed top-4 right-4 z-50">
+  <body class="bg-white dark:bg-gray-900 transition-theme">
+    <% if user_signed_in? %>
+      <nav class="bg-white dark:bg-gray-800 shadow-sm border-b border-gray-200 dark:border-gray-700 transition-theme">
+        <div class="mx-auto max-w-7xl px-4 sm:px-6 lg:px-8">
+          <div class="flex h-16 justify-between">
+            <div class="flex">
+              <div class="flex flex-shrink-0 items-center">
+                <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Finance App</h1>
+              </div>
+              <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
+                <%= link_to "Transactions", transactions_path, 
+                    class: "inline-flex items-center border-b-2 #{current_page?(transactions_path) ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'} px-1 pt-1 text-sm font-medium transition-theme" %>
+                <%= link_to "Categories", categories_path,
+                    class: "inline-flex items-center border-b-2 #{current_page?(categories_path) ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'} px-1 pt-1 text-sm font-medium transition-theme" %>
+              </div>
+            </div>
+            <div class="flex items-center space-x-4">
+              <!-- Theme Toggle -->
+              <button type="button"
+                      data-action="click->theme#toggle"
+                      class="p-2 text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white rounded-lg hover:bg-gray-100 dark:hover:bg-gray-700 transition-all">
+                <svg data-theme-target="icon" class="w-5 h-5" fill="currentColor" viewBox="0 0 20 20">
+                  <!-- Icon will be inserted by Stimulus controller -->
+                </svg>
+              </button>
+              
+              <!-- User Menu -->
+              <div class="relative">
+                <button type="button" class="flex items-center text-sm rounded-full">
+                  <span class="text-gray-700 dark:text-gray-300 mr-2"><%= current_user.email %></span>
+                </button>
+              </div>
+              
+              <%= button_to "Sign out", destroy_user_session_path, method: :delete,
+                  class: "text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white" %>
+            </div>
+          </div>
+        </div>
+      </nav>
+    <% end %>
+    
+    <div id="flash" class="fixed top-20 right-4 z-50">
       <% if notice.present? %>
-        <div class="bg-green-100 border border-green-400 text-green-700 px-4 py-3 rounded mb-4" role="alert">
+        <div class="bg-green-100 dark:bg-green-900 border border-green-400 dark:border-green-600 text-green-700 dark:text-green-200 px-4 py-3 rounded mb-4 transition-theme" role="alert">
           <span class="block sm:inline"><%= notice %></span>
         </div>
       <% end %>
       
       <% if alert.present? %>
-        <div class="bg-red-100 border border-red-400 text-red-700 px-4 py-3 rounded mb-4" role="alert">
+        <div class="bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-200 px-4 py-3 rounded mb-4 transition-theme" role="alert">
           <span class="block sm:inline"><%= alert %></span>
         </div>
       <% end %>
     </div>
     
-    <main>
+    <main class="min-h-screen bg-gray-50 dark:bg-gray-900 transition-theme <%= user_signed_in? ? 'pt-8' : '' %>">
       <%= yield %>
     </main>
   </body>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -1,17 +1,17 @@
 <%= form_with(model: transaction, local: false) do |form| %>
   <% if transaction.errors.any? %>
-    <div class="rounded-md bg-red-50 p-4 mb-4">
+    <div class="rounded-md bg-red-50 dark:bg-red-900/20 p-4 mb-4">
       <div class="flex">
         <div class="flex-shrink-0">
-          <svg class="h-5 w-5 text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <svg class="h-5 w-5 text-red-400 dark:text-red-300" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zM8.707 7.293a1 1 0 00-1.414 1.414L8.586 10l-1.293 1.293a1 1 0 101.414 1.414L10 11.414l1.293 1.293a1 1 0 001.414-1.414L11.414 10l1.293-1.293a1 1 0 00-1.414-1.414L10 8.586 8.707 7.293z" clip-rule="evenodd" />
           </svg>
         </div>
         <div class="ml-3">
-          <h3 class="text-sm font-medium text-red-800">
+          <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
             There were <%= pluralize(transaction.errors.count, "error") %> with your submission
           </h3>
-          <div class="mt-2 text-sm text-red-700">
+          <div class="mt-2 text-sm text-red-700 dark:text-red-300">
             <ul class="list-disc pl-5 space-y-1">
               <% transaction.errors.full_messages.each do |message| %>
                 <li><%= message %></li>
@@ -25,35 +25,35 @@
 
   <div class="space-y-6">
     <fieldset>
-      <legend class="text-sm font-medium text-gray-700">Transaction Type</legend>
+      <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">Transaction Type</legend>
       <div class="mt-2 grid grid-cols-2 gap-3">
-        <label class="relative flex cursor-pointer rounded-lg border bg-white p-4 shadow-sm focus:outline-none">
+        <label class="relative flex cursor-pointer rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 p-4 shadow-sm focus:outline-none">
           <%= form.radio_button :transaction_type, "income", 
               class: "sr-only",
               data: { action: "change->transaction-form#updateAmountColor" } %>
           <span class="flex flex-1">
             <span class="flex flex-col">
-              <span class="block text-sm font-medium text-gray-900">Income</span>
-              <span class="mt-1 flex items-center text-sm text-gray-500">Money coming in</span>
+              <span class="block text-sm font-medium text-gray-900 dark:text-white">Income</span>
+              <span class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400">Money coming in</span>
             </span>
           </span>
-          <svg class="h-5 w-5 text-green-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <svg class="h-5 w-5 text-green-600 dark:text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 11.414l3.293 3.293a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
           </svg>
           <span class="pointer-events-none absolute -inset-px rounded-lg border-2" aria-hidden="true"></span>
         </label>
         
-        <label class="relative flex cursor-pointer rounded-lg border bg-white p-4 shadow-sm focus:outline-none">
+        <label class="relative flex cursor-pointer rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 p-4 shadow-sm focus:outline-none">
           <%= form.radio_button :transaction_type, "expense", 
               class: "sr-only",
               data: { action: "change->transaction-form#updateAmountColor" } %>
           <span class="flex flex-1">
             <span class="flex flex-col">
-              <span class="block text-sm font-medium text-gray-900">Expense</span>
-              <span class="mt-1 flex items-center text-sm text-gray-500">Money going out</span>
+              <span class="block text-sm font-medium text-gray-900 dark:text-white">Expense</span>
+              <span class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400">Money going out</span>
             </span>
           </span>
-          <svg class="h-5 w-5 text-red-600" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
+          <svg class="h-5 w-5 text-red-600 dark:text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
             <path fill-rule="evenodd" d="M10 18a8 8 0 100-16 8 8 0 000 16zm3.707-9.293a1 1 0 00-1.414-1.414L9 10.586 7.707 9.293a1 1 0 00-1.414 0l-2 2a1 1 0 101.414 1.414L8 11.414l3.293 3.293a1 1 0 001.414 0l4-4z" clip-rule="evenodd" />
           </svg>
           <span class="pointer-events-none absolute -inset-px rounded-lg border-2" aria-hidden="true"></span>
@@ -62,44 +62,44 @@
     </fieldset>
     
     <div>
-      <%= form.label :amount, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.label :amount, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="relative mt-1 rounded-md shadow-sm">
         <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-          <span class="text-gray-500 sm:text-sm">$</span>
+          <span class="text-gray-500 dark:text-gray-400 sm:text-sm">$</span>
         </div>
         <%= form.number_field :amount, 
             step: 0.01,
             min: 0.01,
-            class: "block w-full rounded-md border-gray-300 pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+            class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
             placeholder: "0.00",
             data: { transaction_form_target: "amountInput" } %>
       </div>
     </div>
     
     <div>
-      <%= form.label :date, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.label :date, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="mt-1">
         <%= form.date_field :date, 
-            class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+            class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
       </div>
     </div>
     
     <div>
-      <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700" %>
+      <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="mt-1">
         <%= form.select :category_id,
             options_for_select(@categories.map { |c| [c.name, c.id, { "data-color" => c.color }] }, transaction.category_id),
             { prompt: "Select a category" },
-            class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
+            class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm" %>
       </div>
     </div>
     
     <div>
-      <%= form.label :description, class: "block text-sm font-medium text-gray-700" %>
+      <%= form.label :description, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="mt-1">
         <%= form.text_area :description, 
             rows: 3,
-            class: "block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+            class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
             placeholder: "Optional notes about this transaction" %>
       </div>
     </div>
@@ -107,8 +107,8 @@
 
   <div class="mt-6 flex items-center justify-end space-x-3">
     <%= link_to "Cancel", transactions_path, 
-        class: "rounded-md border border-gray-300 bg-white py-2 px-4 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2",
+        class: "rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 py-2 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800",
         data: { controller: "modal", action: "click->modal#close" } %>
-    <%= form.submit class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2" %>
+    <%= form.submit class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800" %>
   </div>
 <% end %>

--- a/app/views/transactions/edit.html.erb
+++ b/app/views/transactions/edit.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag "modal" do %>
   <div class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-90 transition-opacity" 
            data-action="click->modal#close"></div>
 
-      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6"
+      <div class="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6"
            data-controller="transaction-form">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-lg font-medium leading-6 text-gray-900" id="modal-title">
+            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
               Edit Transaction
             </h3>
             <div class="mt-6">

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -2,36 +2,36 @@
   <div class="mx-auto max-w-4xl">
     <div class="sm:flex sm:items-center">
       <div class="sm:flex-auto">
-        <h1 class="text-3xl font-semibold text-gray-900">Transactions</h1>
-        <p class="mt-2 text-sm text-gray-700">
+        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Transactions</h1>
+        <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
           Manage your income and expenses
         </p>
       </div>
       <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
         <%= link_to "New transaction", new_transaction_path, 
-            class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto",
+            class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
             data: { turbo_frame: "modal" } %>
       </div>
     </div>
     
     <div class="mt-8 grid grid-cols-1 gap-4 sm:grid-cols-3">
-      <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-        <dt class="truncate text-sm font-medium text-gray-500">Total Income</dt>
-        <dd class="mt-1 text-2xl font-semibold tracking-tight text-green-600">
+      <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Total Income</dt>
+        <dd class="mt-1 text-2xl font-semibold tracking-tight text-green-600 dark:text-green-400">
           $<%= number_with_precision(@totals[:income], precision: 2) %>
         </dd>
       </div>
       
-      <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-        <dt class="truncate text-sm font-medium text-gray-500">Total Expenses</dt>
-        <dd class="mt-1 text-2xl font-semibold tracking-tight text-red-600">
+      <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Total Expenses</dt>
+        <dd class="mt-1 text-2xl font-semibold tracking-tight text-red-600 dark:text-red-400">
           $<%= number_with_precision(@totals[:expense], precision: 2) %>
         </dd>
       </div>
       
-      <div class="overflow-hidden rounded-lg bg-white px-4 py-5 shadow sm:p-6">
-        <dt class="truncate text-sm font-medium text-gray-500">Balance</dt>
-        <dd class="mt-1 text-2xl font-semibold tracking-tight <%= @totals[:balance] >= 0 ? 'text-green-600' : 'text-red-600' %>">
+      <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6">
+        <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Balance</dt>
+        <dd class="mt-1 text-2xl font-semibold tracking-tight <%= @totals[:balance] >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %>">
           $<%= number_with_precision(@totals[:balance], precision: 2) %>
         </dd>
       </div>
@@ -39,30 +39,30 @@
     
     <%= turbo_frame_tag "transactions_filters", data: { controller: "filters" } do %>
       <%= form_with url: transactions_path, method: :get, data: { turbo_frame: "transactions_list", turbo_action: "advance" } do |f| %>
-        <div class="mt-8 bg-white shadow sm:rounded-lg">
+        <div class="mt-8 bg-white dark:bg-gray-800 shadow sm:rounded-lg">
           <div class="px-4 py-5 sm:p-6">
-            <h3 class="text-lg font-medium leading-6 text-gray-900">Filters</h3>
+            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white">Filters</h3>
             <div class="mt-5 grid grid-cols-1 gap-4 sm:grid-cols-2 lg:grid-cols-4">
               <div>
-                <%= f.label :transaction_type, class: "block text-sm font-medium text-gray-700" %>
+                <%= f.label :transaction_type, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.select :transaction_type, 
                     options_for_select([["All", ""], ["Income", "income"], ["Expense", "expense"]], params[:transaction_type]),
                     {},
-                    class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                    class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#submit" } %>
               </div>
               
               <div>
-                <%= f.label :category_id, "Category", class: "block text-sm font-medium text-gray-700" %>
+                <%= f.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.select :category_id,
                     options_for_select([["All Categories", ""]] + @categories.map { |c| [c.name, c.id] }, params[:category_id]),
                     {},
-                    class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                    class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#submit" } %>
               </div>
               
               <div>
-                <%= f.label :period, class: "block text-sm font-medium text-gray-700" %>
+                <%= f.label :period, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.select :period,
                     options_for_select([
                       ["All time", ""],
@@ -72,30 +72,30 @@
                       ["Custom range", "custom"]
                     ], params[:period]),
                     {},
-                    class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                    class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#toggleDateInputs change->filters#submit" } %>
               </div>
               
               <div class="flex items-end">
                 <%= link_to "Clear filters", transactions_path,
-                    class: "inline-flex items-center rounded-md border border-gray-300 bg-white px-4 py-2 text-sm font-medium text-gray-700 shadow-sm hover:bg-gray-50 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2",
+                    class: "inline-flex items-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800",
                     data: { turbo_frame: "transactions_list" } %>
               </div>
             </div>
             
             <div class="mt-4 grid grid-cols-1 gap-4 sm:grid-cols-2 <%= 'hidden' unless params[:period] == 'custom' %>" data-filters-target="dateInputs">
               <div>
-                <%= f.label :start_date, class: "block text-sm font-medium text-gray-700" %>
+                <%= f.label :start_date, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.date_field :start_date, 
                     value: params[:start_date],
-                    class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                    class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#submit" } %>
               </div>
               <div>
-                <%= f.label :end_date, class: "block text-sm font-medium text-gray-700" %>
+                <%= f.label :end_date, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.date_field :end_date,
                     value: params[:end_date],
-                    class: "mt-1 block w-full rounded-md border-gray-300 shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
+                    class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#submit" } %>
               </div>
             </div>
@@ -108,20 +108,20 @@
       <div class="mt-8 flow-root">
         <div class="-my-2 -mx-4 overflow-x-auto sm:-mx-6 lg:-mx-8">
           <div class="inline-block min-w-full py-2 align-middle sm:px-6 lg:px-8">
-            <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 md:rounded-lg">
-              <table class="min-w-full divide-y divide-gray-300 hidden sm:table">
-                <thead class="bg-gray-50">
+            <div class="overflow-hidden shadow ring-1 ring-black ring-opacity-5 dark:ring-gray-700 md:rounded-lg">
+              <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700 hidden sm:table">
+                <thead class="bg-gray-50 dark:bg-gray-800">
                   <tr>
-                    <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 sm:pl-6">
+                    <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white sm:pl-6">
                       Date
                     </th>
-                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
                       Description
                     </th>
-                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
                       Category
                     </th>
-                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900">
+                    <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
                       Amount
                     </th>
                     <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
@@ -129,31 +129,31 @@
                     </th>
                   </tr>
                 </thead>
-                <tbody class="divide-y divide-gray-200 bg-white">
+                <tbody class="divide-y divide-gray-200 dark:divide-gray-700 bg-white dark:bg-gray-900">
                   <% @transactions.each do |transaction| %>
                     <%= turbo_frame_tag dom_id(transaction) do %>
                       <tr>
-                        <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 sm:pl-6">
+                        <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 dark:text-white sm:pl-6">
                           <%= transaction.date.strftime("%b %d, %Y") %>
                         </td>
-                        <td class="px-3 py-4 text-sm text-gray-900">
+                        <td class="px-3 py-4 text-sm text-gray-900 dark:text-white">
                           <%= transaction.description %>
                         </td>
-                        <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500">
+                        <td class="whitespace-nowrap px-3 py-4 text-sm text-gray-500 dark:text-gray-400">
                           <span class="inline-flex items-center">
                             <span class="h-3 w-3 rounded-full mr-2" style="background-color: <%= transaction.category_color %>"></span>
                             <%= transaction.category_name %>
                           </span>
                         </td>
-                        <td class="whitespace-nowrap px-3 py-4 text-sm font-medium <%= transaction.income? ? 'text-green-600' : 'text-red-600' %>">
+                        <td class="whitespace-nowrap px-3 py-4 text-sm font-medium <%= transaction.income? ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %>">
                           <%= transaction.income? ? '+' : '-' %>$<%= number_with_precision(transaction.amount, precision: 2) %>
                         </td>
                         <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
                           <%= link_to "Edit", edit_transaction_path(transaction), 
-                              class: "text-indigo-600 hover:text-indigo-900",
+                              class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300",
                               data: { turbo_frame: "modal" } %>
                           <%= link_to "Delete", transaction_path(transaction), 
-                              class: "ml-4 text-red-600 hover:text-red-900",
+                              class: "ml-4 text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300",
                               data: { 
                                 turbo_method: :delete,
                                 turbo_confirm: "Are you sure?"
@@ -168,18 +168,18 @@
               <div class="sm:hidden">
                 <% @transactions.each do |transaction| %>
                   <%= turbo_frame_tag dom_id(transaction) do %>
-                    <div class="border-b border-gray-200 bg-white px-4 py-4">
+                    <div class="border-b border-gray-200 dark:border-gray-700 bg-white dark:bg-gray-900 px-4 py-4">
                       <div class="flex items-center justify-between">
                         <div class="flex-1">
                           <div class="flex items-center justify-between">
-                            <p class="text-sm font-medium text-gray-900"><%= transaction.description %></p>
-                            <p class="text-sm font-medium <%= transaction.income? ? 'text-green-600' : 'text-red-600' %>">
+                            <p class="text-sm font-medium text-gray-900 dark:text-white"><%= transaction.description %></p>
+                            <p class="text-sm font-medium <%= transaction.income? ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %>">
                               <%= transaction.income? ? '+' : '-' %>$<%= number_with_precision(transaction.amount, precision: 2) %>
                             </p>
                           </div>
                           <div class="mt-1 flex items-center justify-between">
-                            <p class="text-xs text-gray-500"><%= transaction.date.strftime("%b %d, %Y") %></p>
-                            <span class="inline-flex items-center text-xs text-gray-500">
+                            <p class="text-xs text-gray-500 dark:text-gray-400"><%= transaction.date.strftime("%b %d, %Y") %></p>
+                            <span class="inline-flex items-center text-xs text-gray-500 dark:text-gray-400">
                               <span class="h-2 w-2 rounded-full mr-1" style="background-color: <%= transaction.category_color %>"></span>
                               <%= transaction.category_name %>
                             </span>
@@ -188,10 +188,10 @@
                       </div>
                       <div class="mt-2 flex space-x-3 text-xs">
                         <%= link_to "Edit", edit_transaction_path(transaction), 
-                            class: "text-indigo-600",
+                            class: "text-indigo-600 dark:text-indigo-400",
                             data: { turbo_frame: "modal" } %>
                         <%= link_to "Delete", transaction_path(transaction), 
-                            class: "text-red-600",
+                            class: "text-red-600 dark:text-red-400",
                             data: { 
                               turbo_method: :delete,
                               turbo_confirm: "Are you sure?"

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -1,14 +1,14 @@
 <%= turbo_frame_tag "modal" do %>
   <div class="fixed inset-0 z-10 overflow-y-auto" aria-labelledby="modal-title" role="dialog" aria-modal="true">
     <div class="flex min-h-full items-end justify-center p-4 text-center sm:items-center sm:p-0">
-      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 transition-opacity" 
+      <div class="fixed inset-0 bg-gray-500 bg-opacity-75 dark:bg-gray-900 dark:bg-opacity-90 transition-opacity" 
            data-action="click->modal#close"></div>
 
-      <div class="relative transform overflow-hidden rounded-lg bg-white px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6"
+      <div class="relative transform overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 pt-5 pb-4 text-left shadow-xl transition-all sm:my-8 sm:w-full sm:max-w-lg sm:p-6"
            data-controller="transaction-form">
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
-            <h3 class="text-lg font-medium leading-6 text-gray-900" id="modal-title">
+            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
               New Transaction
             </h3>
             <div class="mt-6">

--- a/config/tailwind.config.js
+++ b/config/tailwind.config.js
@@ -1,0 +1,31 @@
+module.exports = {
+  darkMode: 'class',
+  content: [
+    './public/*.html',
+    './app/helpers/**/*.rb',
+    './app/javascript/**/*.js',
+    './app/views/**/*.{erb,haml,html,slim}'
+  ],
+  theme: {
+    extend: {
+      colors: {
+        // Custom colors for dark mode
+        dark: {
+          bg: '#0f172a',
+          surface: '#1e293b',
+          border: '#334155',
+          text: '#e2e8f0',
+          muted: '#94a3b8'
+        }
+      },
+      transitionProperty: {
+        'theme': 'background-color, border-color, color, fill, stroke'
+      }
+    }
+  },
+  plugins: [
+    require('@tailwindcss/forms'),
+    require('@tailwindcss/typography'),
+    require('@tailwindcss/container-queries'),
+  ]
+}


### PR DESCRIPTION
## Summary
  - Implemented a subtle dark mode theme with light gray backgrounds instead of deep blacks
  - Added theme toggle button in navigation with sun/moon icons
  - Theme preference persists using localStorage

  ## Changes
  - Created Stimulus theme controller for toggle functionality
  - Updated all views (Categories and Transactions) with dark mode classes
  - Added smooth CSS transitions between themes
  - Configured custom dark mode colors for better visual comfort
  - Improved spacing between navigation and main content

  ## Test plan
  - [ ] Click theme toggle button - should switch between light/dark modes
  - [ ] Refresh page - theme preference should persist
  - [ ] Navigate between pages - theme should remain consistent
  - [ ] Check all forms and modals work correctly in both themes
  - [ ] Verify colors are subtle and comfortable in dark mode
