### PR TITLE
fix: resolve Devise authentication error handling

### DIFF
--- a/app/controllers/turbo_devise_controller.rb
+++ b/app/controllers/turbo_devise_controller.rb
@@ -11,7 +11,7 @@ class TurboDeviseController < ApplicationController
         begin
           redirect_to navigation_location
         rescue NoMethodError => e
-          if e.message.include?('users_url')
+          if e.message.include?("users_url")
             controller.redirect_to controller.new_user_session_path
           else
             raise e
@@ -27,7 +27,7 @@ class TurboDeviseController < ApplicationController
         begin
           super
         rescue NoMethodError => e
-          if e.message.include?('users_url')
+          if e.message.include?("users_url")
             controller.redirect_to controller.new_user_session_path
           else
             raise e
@@ -46,14 +46,14 @@ class TurboDeviseController < ApplicationController
     if resource.persisted?
       redirect_to after_sign_in_path_for(resource)
     else
-      if resource.errors.empty? && controller_name == 'sessions' && action_name == 'create'
+      if resource.errors.empty? && controller_name == "sessions" && action_name == "create"
         flash.now[:alert] = "Invalid email or password."
       end
       begin
         super
       rescue NoMethodError => e
-        if e.message.include?('users_url')
-          render 'new', status: :unprocessable_entity, formats: [:html]
+        if e.message.include?("users_url")
+          render "new", status: :unprocessable_entity, formats: [ :html ]
         else
           raise e
         end

--- a/app/controllers/turbo_devise_controller.rb
+++ b/app/controllers/turbo_devise_controller.rb
@@ -8,7 +8,31 @@ class TurboDeviseController < ApplicationController
       elsif has_errors? && default_action
         render rendering_options.merge(formats: :html, status: :unprocessable_entity)
       else
-        redirect_to navigation_location
+        begin
+          redirect_to navigation_location
+        rescue NoMethodError => e
+          if e.message.include?('users_url')
+            controller.redirect_to controller.new_user_session_path
+          else
+            raise e
+          end
+        end
+      end
+    end
+
+    def to_html
+      if has_errors? && default_action
+        render rendering_options.merge(status: :unprocessable_entity)
+      else
+        begin
+          super
+        rescue NoMethodError => e
+          if e.message.include?('users_url')
+            controller.redirect_to controller.new_user_session_path
+          else
+            raise e
+          end
+        end
       end
     end
   end
@@ -22,7 +46,18 @@ class TurboDeviseController < ApplicationController
     if resource.persisted?
       redirect_to after_sign_in_path_for(resource)
     else
-      super
+      if resource.errors.empty? && controller_name == 'sessions' && action_name == 'create'
+        flash.now[:alert] = "Invalid email or password."
+      end
+      begin
+        super
+      rescue NoMethodError => e
+        if e.message.include?('users_url')
+          render 'new', status: :unprocessable_entity, formats: [:html]
+        else
+          raise e
+        end
+      end
     end
   end
 end

--- a/app/views/devise/shared/_error_messages.html.erb
+++ b/app/views/devise/shared/_error_messages.html.erb
@@ -1,12 +1,12 @@
 <% if resource.errors.any? %>
-  <div id="error_explanation" data-turbo-cache="false">
-    <h2>
+  <div id="error_explanation" class="bg-red-100 dark:bg-red-900 border border-red-400 dark:border-red-600 text-red-700 dark:text-red-200 px-4 py-3 rounded mb-4" data-turbo-cache="false">
+    <h2 class="font-bold mb-2">
       <%= I18n.t("errors.messages.not_saved",
                  count: resource.errors.count,
                  resource: resource.class.model_name.human.downcase)
        %>
     </h2>
-    <ul>
+    <ul class="list-disc list-inside">
       <% resource.errors.full_messages.each do |message| %>
         <li><%= message %></li>
       <% end %>


### PR DESCRIPTION
- Fix NoMethodError for undefined users_url in TurboDeviseController
- Add proper error handling for both HTML and Turbo Stream responses
- Implement fallback authentication error messages for failed logins
- Style error messages with consistent dark/light theme support
- Ensure proper template rendering when authentication fails