### PR TITLE
feat: add CSV export for dashboard transactions

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -4,6 +4,7 @@ class DashboardController < ApplicationController
   def index
     @user = Current.user
     @transactions = filtered_transactions
+    @export_transactions = filtered_transactions_for_charts.ordered
 
     # Goals data
     @goals = Current.user.goals.includes(:category).ordered
@@ -21,6 +22,13 @@ class DashboardController < ApplicationController
 
     respond_to do |format|
       format.html
+      format.csv do
+        send_data(
+          Export::TransactionsCsv.new(transactions: @export_transactions).call,
+          filename: export_filename,
+          type: "text/csv; charset=utf-8"
+        )
+      end
       format.turbo_stream do
         render turbo_stream: [
           turbo_stream.update("charts_and_transactions",
@@ -129,5 +137,9 @@ class DashboardController < ApplicationController
 
   def load_categories
     @categories = Current.user.categories.ordered
+  end
+
+  def export_filename
+    "transactions-#{Date.current}.csv"
   end
 end

--- a/app/services/export/transactions_csv.rb
+++ b/app/services/export/transactions_csv.rb
@@ -1,0 +1,27 @@
+require "csv"
+
+module Export
+  class TransactionsCsv
+    HEADERS = [ "Date", "Type", "Category", "Description", "Amount" ].freeze
+
+    def initialize(transactions:)
+      @transactions = transactions.includes(:category)
+    end
+
+    def call
+      CSV.generate(headers: true) do |csv|
+        csv << HEADERS
+
+        @transactions.each do |transaction|
+          csv << [
+            transaction.date,
+            transaction.transaction_type,
+            transaction.category_name,
+            transaction.description,
+            format("%.2f", transaction.amount)
+          ]
+        end
+      end
+    end
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -8,9 +8,18 @@
         </p>
       </div>
       <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-        <%= link_to "New transaction", new_transaction_path, 
-            class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
-            data: { turbo_frame: "modal" } %>
+        <div class="flex items-center gap-2">
+          <%= link_to "Export CSV",
+              dashboard_path(
+                request.query_parameters.slice("transaction_type", "category_id", "search", "period", "start_date", "end_date").merge(format: :csv)
+              ),
+              class: "inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
+              data: { turbo: false } %>
+
+          <%= link_to "New transaction", new_transaction_path,
+              class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
+              data: { turbo_frame: "modal" } %>
+        </div>
       </div>
     </div>
     

--- a/spec/controllers/dashboard_csv_export_spec.rb
+++ b/spec/controllers/dashboard_csv_export_spec.rb
@@ -1,0 +1,69 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe DashboardController, type: :controller do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  let(:food) { create(:category, user: user, name: "Food") }
+  let(:salary) { create(:category, user: user, name: "Salary") }
+  let(:other_category) { create(:category, user: other_user, name: "Other") }
+
+  before do
+    routes.draw { get "dashboard" => "dashboard#index" }
+
+    sign_in user
+
+    create(:transaction, :expense, user: user, category: food, amount: 25, description: "Coffee", date: Date.current)
+    create(:transaction, :income, user: user, category: salary, amount: 2000, description: "Paycheck", date: Date.current)
+    create(:transaction, :income, user: other_user, category: other_category, amount: 9999, description: "Should not export", date: Date.current)
+  end
+
+  it "exports only current user transactions in CSV format" do
+    get :index, format: :csv
+
+    expect(response).to have_http_status(:ok)
+    expect(response.content_type).to include("text/csv")
+
+    parsed = CSV.parse(response.body, headers: true)
+    descriptions = parsed.map { |row| row["Description"] }
+
+    expect(descriptions).to include("Coffee", "Paycheck")
+    expect(descriptions).not_to include("Should not export")
+  end
+
+  it "applies transaction_type filter to exported CSV" do
+    get :index, params: { transaction_type: "income" }, format: :csv
+
+    parsed = CSV.parse(response.body, headers: true)
+    types = parsed.map { |row| row["Type"] }.uniq
+
+    expect(types).to eq([ "income" ])
+    expect(parsed.map { |row| row["Description"] }).to include("Paycheck")
+    expect(parsed.map { |row| row["Description"] }).not_to include("Coffee")
+  end
+
+  it "applies custom date range filter to exported CSV" do
+    old_transaction = create(
+      :transaction,
+      :expense,
+      user: user,
+      category: food,
+      amount: 10,
+      description: "Old expense",
+      date: 3.months.ago.to_date
+    )
+
+    get :index, params: {
+      period: "custom",
+      start_date: Date.current.beginning_of_month,
+      end_date: Date.current.end_of_month
+    }, format: :csv
+
+    parsed = CSV.parse(response.body, headers: true)
+    descriptions = parsed.map { |row| row["Description"] }
+
+    expect(descriptions).not_to include(old_transaction.description)
+    expect(descriptions).to include("Coffee", "Paycheck")
+  end
+end

--- a/spec/services/export/transactions_csv_spec.rb
+++ b/spec/services/export/transactions_csv_spec.rb
@@ -1,0 +1,32 @@
+require "rails_helper"
+require "csv"
+
+RSpec.describe Export::TransactionsCsv do
+  describe "#call" do
+    let(:user) { create(:user) }
+    let(:category) { create(:category, user: user, name: "Food") }
+
+    it "generates CSV with expected headers and rows" do
+      transaction = create(
+        :transaction,
+        :expense,
+        user: user,
+        category: category,
+        amount: 45.5,
+        date: Date.new(2026, 4, 10),
+        description: "Lunch"
+      )
+
+      csv_content = described_class.new(transactions: Transaction.where(id: transaction.id)).call
+      parsed = CSV.parse(csv_content, headers: true)
+
+      expect(parsed.headers).to eq([ "Date", "Type", "Category", "Description", "Amount" ])
+      expect(parsed.length).to eq(1)
+      expect(parsed[0]["Date"]).to eq("2026-04-10")
+      expect(parsed[0]["Type"]).to eq("expense")
+      expect(parsed[0]["Category"]).to eq("Food")
+      expect(parsed[0]["Description"]).to eq("Lunch")
+      expect(parsed[0]["Amount"]).to eq("45.50")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
- add CSV export action on dashboard with active filters preserved
- add Export::TransactionsCsv service for CSV generation
- add controller and service specs for CSV export behavior

## Validation
- docker compose run --rm web bundle exec rspec
- docker compose run --rm web bundle exec rubocop
- docker compose run --rm web bundle exec brakeman -q
