### PR TITLE
feat: add Solid Queue background jobs and monitoring (FIN-33)

### DIFF
--- a/app/controllers/jobs_controller.rb
+++ b/app/controllers/jobs_controller.rb
@@ -1,0 +1,5 @@
+class JobsController < ApplicationController
+  def monitoring
+    @snapshot = Jobs::MonitoringSnapshot.new.call
+  end
+end

--- a/app/jobs/enqueue_goal_due_soon_notifications_job.rb
+++ b/app/jobs/enqueue_goal_due_soon_notifications_job.rb
@@ -1,0 +1,9 @@
+class EnqueueGoalDueSoonNotificationsJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Goal.active_goals.due_soon.find_each do |goal|
+      GoalDueSoonNotificationJob.perform_later(goal.id)
+    end
+  end
+end

--- a/app/jobs/enqueue_monthly_financial_reports_job.rb
+++ b/app/jobs/enqueue_monthly_financial_reports_job.rb
@@ -1,0 +1,9 @@
+class EnqueueMonthlyFinancialReportsJob < ApplicationJob
+  queue_as :reports
+
+  def perform(reference_month = Date.current.prev_month.iso8601)
+    User.find_each do |user|
+      MonthlyFinancialReportJob.perform_later(user.id, reference_month)
+    end
+  end
+end

--- a/app/jobs/goal_due_soon_notification_job.rb
+++ b/app/jobs/goal_due_soon_notification_job.rb
@@ -1,0 +1,10 @@
+class GoalDueSoonNotificationJob < ApplicationJob
+  queue_as :default
+
+  def perform(goal_id)
+    goal = Goal.includes(:user).find_by(id: goal_id)
+    return unless goal&.active? && goal.due_soon?
+
+    GoalNotificationsMailer.due_soon(goal).deliver_now
+  end
+end

--- a/app/jobs/monthly_financial_report_job.rb
+++ b/app/jobs/monthly_financial_report_job.rb
@@ -1,0 +1,21 @@
+class MonthlyFinancialReportJob < ApplicationJob
+  queue_as :reports
+
+  def perform(user_id, reference_month = Date.current.prev_month.iso8601)
+    user = User.find_by(id: user_id)
+    return unless user
+
+    reference_date = parse_reference_month(reference_month)
+    summary = Reports::MonthlySummary.new(user: user, reference_date: reference_date).call
+
+    ReportsMailer.monthly_summary(user, summary).deliver_now
+  end
+
+  private
+
+  def parse_reference_month(reference_month)
+    Date.parse(reference_month.to_s).beginning_of_month
+  rescue Date::Error
+    Date.current.prev_month.beginning_of_month
+  end
+end

--- a/app/mailers/goal_notifications_mailer.rb
+++ b/app/mailers/goal_notifications_mailer.rb
@@ -1,0 +1,11 @@
+class GoalNotificationsMailer < ApplicationMailer
+  def due_soon(goal)
+    @goal = goal
+    @user = goal.user
+
+    mail(
+      to: @user.email,
+      subject: "Goal due soon: #{@goal.title}"
+    )
+  end
+end

--- a/app/mailers/reports_mailer.rb
+++ b/app/mailers/reports_mailer.rb
@@ -1,0 +1,11 @@
+class ReportsMailer < ApplicationMailer
+  def monthly_summary(user, summary)
+    @user = user
+    @summary = summary
+
+    mail(
+      to: @user.email,
+      subject: "Monthly financial report (#{@summary[:month]})"
+    )
+  end
+end

--- a/app/services/jobs/monitoring_snapshot.rb
+++ b/app/services/jobs/monitoring_snapshot.rb
@@ -1,0 +1,35 @@
+module Jobs
+  class MonitoringSnapshot
+    def call
+      return default_snapshot unless solid_queue_available?
+
+      {
+        pending: SolidQueue::ReadyExecution.count + SolidQueue::ScheduledExecution.count,
+        running: SolidQueue::ClaimedExecution.count,
+        failed: SolidQueue::FailedExecution.count,
+        finished: SolidQueue::Job.where.not(finished_at: nil).count
+      }
+    rescue ActiveRecord::StatementInvalid, ActiveRecord::NoDatabaseError
+      default_snapshot
+    end
+
+    private
+
+    def solid_queue_available?
+      defined?(SolidQueue::Job) &&
+        defined?(SolidQueue::ReadyExecution) &&
+        defined?(SolidQueue::ScheduledExecution) &&
+        defined?(SolidQueue::ClaimedExecution) &&
+        defined?(SolidQueue::FailedExecution)
+    end
+
+    def default_snapshot
+      {
+        pending: 0,
+        running: 0,
+        failed: 0,
+        finished: 0
+      }
+    end
+  end
+end

--- a/app/services/reports/monthly_summary.rb
+++ b/app/services/reports/monthly_summary.rb
@@ -1,0 +1,26 @@
+module Reports
+  class MonthlySummary
+    def initialize(user:, reference_date:)
+      @user = user
+      @reference_date = reference_date.beginning_of_month
+    end
+
+    def call
+      income = scoped_transactions.income.sum(:amount)
+      expenses = scoped_transactions.expense.sum(:amount)
+
+      {
+        month: @reference_date.strftime("%Y-%m"),
+        income: income,
+        expenses: expenses,
+        balance: income - expenses
+      }
+    end
+
+    private
+
+    def scoped_transactions
+      @user.transactions.by_month(@reference_date)
+    end
+  end
+end

--- a/app/views/goal_notifications_mailer/due_soon.text.erb
+++ b/app/views/goal_notifications_mailer/due_soon.text.erb
@@ -1,0 +1,8 @@
+Hi <%= @user.email %>,
+
+Your goal "<%= @goal.title %>" is due in <%= @goal.days_remaining %> day(s).
+Current progress: <%= number_to_percentage(@goal.progress_percentage, precision: 0) %>
+Target amount: <%= number_to_currency(@goal.target_amount) %>
+Current amount: <%= number_to_currency(@goal.current_amount) %>
+
+Keep going!

--- a/app/views/jobs/monitoring.html.erb
+++ b/app/views/jobs/monitoring.html.erb
@@ -1,0 +1,28 @@
+<div class="max-w-3xl mx-auto px-4 py-8">
+  <div class="mb-6">
+    <h1 class="text-2xl font-bold text-gray-900">Jobs Monitoring</h1>
+    <p class="text-sm text-gray-600">Current background processing snapshot from Solid Queue.</p>
+  </div>
+
+  <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
+    <div class="rounded-lg border border-gray-200 p-4 bg-white">
+      <p class="text-sm text-gray-500">Pending</p>
+      <p class="text-2xl font-semibold text-gray-900"><%= @snapshot[:pending] %></p>
+    </div>
+
+    <div class="rounded-lg border border-gray-200 p-4 bg-white">
+      <p class="text-sm text-gray-500">Running</p>
+      <p class="text-2xl font-semibold text-gray-900"><%= @snapshot[:running] %></p>
+    </div>
+
+    <div class="rounded-lg border border-gray-200 p-4 bg-white">
+      <p class="text-sm text-gray-500">Failed</p>
+      <p class="text-2xl font-semibold text-red-600"><%= @snapshot[:failed] %></p>
+    </div>
+
+    <div class="rounded-lg border border-gray-200 p-4 bg-white">
+      <p class="text-sm text-gray-500">Finished</p>
+      <p class="text-2xl font-semibold text-emerald-600"><%= @snapshot[:finished] %></p>
+    </div>
+  </div>
+</div>

--- a/app/views/reports_mailer/monthly_summary.text.erb
+++ b/app/views/reports_mailer/monthly_summary.text.erb
@@ -1,0 +1,9 @@
+Hi <%= @user.email %>,
+
+Here is your monthly financial summary for <%= @summary[:month] %>:
+
+- Income: <%= number_to_currency(@summary[:income]) %>
+- Expenses: <%= number_to_currency(@summary[:expenses]) %>
+- Balance: <%= number_to_currency(@summary[:balance]) %>
+
+Generated automatically by Finance App.

--- a/bin/jobs
+++ b/bin/jobs
@@ -1,0 +1,6 @@
+#!/usr/bin/env ruby
+
+require_relative "../config/environment"
+require "solid_queue/cli"
+
+SolidQueue::Cli.start(ARGV)

--- a/config/database.yml
+++ b/config/database.yml
@@ -94,3 +94,7 @@ production:
     <<: *primary_production
   writing:
     <<: *primary_production
+  queue:
+    <<: *primary_production
+    url: <%= ENV["QUEUE_DATABASE_URL"] || ENV["DATABASE_URL"] %>
+    schema_dump: db/queue_schema.rb

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -50,7 +50,8 @@ Rails.application.configure do
   # config.cache_store = :mem_cache_store
 
   # Replace the default in-process and non-durable queuing backend for Active Job.
-  # config.active_job.queue_adapter = :resque
+  config.active_job.queue_adapter = :solid_queue
+  config.solid_queue.connects_to = { database: { writing: :queue } }
 
   # Ignore bad email addresses and do not raise email delivery errors.
   # Set this to true and configure the email server for immediate delivery to raise delivery errors.

--- a/config/queue.yml
+++ b/config/queue.yml
@@ -1,0 +1,18 @@
+default: &default
+  dispatchers:
+    - polling_interval: 1
+      batch_size: 500
+  workers:
+    - queues: "*"
+      threads: 3
+      processes: <%= ENV.fetch("JOB_CONCURRENCY", 1) %>
+      polling_interval: 0.1
+
+development:
+  <<: *default
+
+test:
+  <<: *default
+
+production:
+  <<: *default

--- a/config/recurring.yml
+++ b/config/recurring.yml
@@ -1,0 +1,25 @@
+# examples:
+#   periodic_cleanup:
+#     class: CleanSoftDeletedRecordsJob
+#     queue: background
+#     args: [ 1000, { batch_size: 500 } ]
+#     schedule: every hour
+#   periodic_cleanup_with_command:
+#     command: "SoftDeletedRecord.due.delete_all"
+#     priority: 2
+#     schedule: at 5am every day
+
+production:
+  clear_solid_queue_finished_jobs:
+    command: "SolidQueue::Job.clear_finished_in_batches(sleep_between_batches: 0.3)"
+    schedule: every hour at minute 12
+
+  enqueue_goal_due_soon_notifications:
+    class: EnqueueGoalDueSoonNotificationsJob
+    queue: default
+    schedule: every day at 8am
+
+  enqueue_monthly_financial_reports:
+    class: EnqueueMonthlyFinancialReportsJob
+    queue: reports
+    schedule: at 6am on day 1 of every month

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -6,6 +6,7 @@ Rails.application.routes.draw do
   # Authenticated routes
   authenticate :user do
     get "dashboard", to: "dashboard#index"
+    get "jobs/monitoring", to: "jobs#monitoring"
     resources :categories
     resources :transactions
     resources :goals do

--- a/db/queue_schema.rb
+++ b/db/queue_schema.rb
@@ -1,0 +1,129 @@
+ActiveRecord::Schema[7.1].define(version: 1) do
+  create_table "solid_queue_blocked_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.string "concurrency_key", null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.index [ "concurrency_key", "priority", "job_id" ], name: "index_solid_queue_blocked_executions_for_release"
+    t.index [ "expires_at", "concurrency_key" ], name: "index_solid_queue_blocked_executions_for_maintenance"
+    t.index [ "job_id" ], name: "index_solid_queue_blocked_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_claimed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.bigint "process_id"
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_claimed_executions_on_job_id", unique: true
+    t.index [ "process_id", "job_id" ], name: "index_solid_queue_claimed_executions_on_process_id_and_job_id"
+  end
+
+  create_table "solid_queue_failed_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.text "error"
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_failed_executions_on_job_id", unique: true
+  end
+
+  create_table "solid_queue_jobs", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.string "class_name", null: false
+    t.text "arguments"
+    t.integer "priority", default: 0, null: false
+    t.string "active_job_id"
+    t.datetime "scheduled_at"
+    t.datetime "finished_at"
+    t.string "concurrency_key"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "active_job_id" ], name: "index_solid_queue_jobs_on_active_job_id"
+    t.index [ "class_name" ], name: "index_solid_queue_jobs_on_class_name"
+    t.index [ "finished_at" ], name: "index_solid_queue_jobs_on_finished_at"
+    t.index [ "queue_name", "finished_at" ], name: "index_solid_queue_jobs_for_filtering"
+    t.index [ "scheduled_at", "finished_at" ], name: "index_solid_queue_jobs_for_alerting"
+  end
+
+  create_table "solid_queue_pauses", force: :cascade do |t|
+    t.string "queue_name", null: false
+    t.datetime "created_at", null: false
+    t.index [ "queue_name" ], name: "index_solid_queue_pauses_on_queue_name", unique: true
+  end
+
+  create_table "solid_queue_processes", force: :cascade do |t|
+    t.string "kind", null: false
+    t.datetime "last_heartbeat_at", null: false
+    t.bigint "supervisor_id"
+    t.integer "pid", null: false
+    t.string "hostname"
+    t.text "metadata"
+    t.datetime "created_at", null: false
+    t.string "name", null: false
+    t.index [ "last_heartbeat_at" ], name: "index_solid_queue_processes_on_last_heartbeat_at"
+    t.index [ "name", "supervisor_id" ], name: "index_solid_queue_processes_on_name_and_supervisor_id", unique: true
+    t.index [ "supervisor_id" ], name: "index_solid_queue_processes_on_supervisor_id"
+  end
+
+  create_table "solid_queue_ready_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_ready_executions_on_job_id", unique: true
+    t.index [ "priority", "job_id" ], name: "index_solid_queue_poll_all"
+    t.index [ "queue_name", "priority", "job_id" ], name: "index_solid_queue_poll_by_queue"
+  end
+
+  create_table "solid_queue_recurring_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "task_key", null: false
+    t.datetime "run_at", null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_recurring_executions_on_job_id", unique: true
+    t.index [ "task_key", "run_at" ], name: "index_solid_queue_recurring_executions_on_task_key_and_run_at", unique: true
+  end
+
+  create_table "solid_queue_recurring_tasks", force: :cascade do |t|
+    t.string "key", null: false
+    t.string "schedule", null: false
+    t.string "command", limit: 2048
+    t.string "class_name"
+    t.text "arguments"
+    t.string "queue_name"
+    t.integer "priority", default: 0
+    t.boolean "static", default: true, null: false
+    t.text "description"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "key" ], name: "index_solid_queue_recurring_tasks_on_key", unique: true
+    t.index [ "static" ], name: "index_solid_queue_recurring_tasks_on_static"
+  end
+
+  create_table "solid_queue_scheduled_executions", force: :cascade do |t|
+    t.bigint "job_id", null: false
+    t.string "queue_name", null: false
+    t.integer "priority", default: 0, null: false
+    t.datetime "scheduled_at", null: false
+    t.datetime "created_at", null: false
+    t.index [ "job_id" ], name: "index_solid_queue_scheduled_executions_on_job_id", unique: true
+    t.index [ "scheduled_at", "priority", "job_id" ], name: "index_solid_queue_dispatch_all"
+  end
+
+  create_table "solid_queue_semaphores", force: :cascade do |t|
+    t.string "key", null: false
+    t.integer "value", default: 1, null: false
+    t.datetime "expires_at", null: false
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index [ "expires_at" ], name: "index_solid_queue_semaphores_on_expires_at"
+    t.index [ "key", "value" ], name: "index_solid_queue_semaphores_on_key_and_value"
+    t.index [ "key" ], name: "index_solid_queue_semaphores_on_key", unique: true
+  end
+
+  add_foreign_key "solid_queue_blocked_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_claimed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_failed_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_ready_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_recurring_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+  add_foreign_key "solid_queue_scheduled_executions", "solid_queue_jobs", column: "job_id", on_delete: :cascade
+end

--- a/spec/jobs/enqueue_goal_due_soon_notifications_job_spec.rb
+++ b/spec/jobs/enqueue_goal_due_soon_notifications_job_spec.rb
@@ -1,0 +1,23 @@
+require "rails_helper"
+
+RSpec.describe EnqueueGoalDueSoonNotificationsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  let(:user) { create(:user) }
+  let(:category) { create(:category, user: user) }
+
+  before do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  it "enqueues one notification job per due soon active goal" do
+    due_soon_goal = create(:goal, :due_soon, user: user, category: category, status: "active")
+    create(:goal, user: user, category: category, target_date: 1.month.from_now, status: "active")
+    create(:goal, :due_soon, user: user, category: category, status: "paused")
+
+    expect {
+      described_class.perform_now
+    }.to have_enqueued_job(GoalDueSoonNotificationJob).with(due_soon_goal.id).exactly(:once)
+  end
+end

--- a/spec/jobs/enqueue_monthly_financial_reports_job_spec.rb
+++ b/spec/jobs/enqueue_monthly_financial_reports_job_spec.rb
@@ -1,0 +1,21 @@
+require "rails_helper"
+
+RSpec.describe EnqueueMonthlyFinancialReportsJob, type: :job do
+  include ActiveJob::TestHelper
+
+  before do
+    clear_enqueued_jobs
+    clear_performed_jobs
+  end
+
+  it "enqueues monthly report job for each user" do
+    user_one = create(:user)
+    user_two = create(:user)
+    reference_month = "2026-03-01"
+
+    expect {
+      described_class.perform_now(reference_month)
+    }.to have_enqueued_job(MonthlyFinancialReportJob).with(user_one.id, reference_month)
+      .and have_enqueued_job(MonthlyFinancialReportJob).with(user_two.id, reference_month)
+  end
+end

--- a/spec/jobs/goal_due_soon_notification_job_spec.rb
+++ b/spec/jobs/goal_due_soon_notification_job_spec.rb
@@ -1,0 +1,31 @@
+require "rails_helper"
+
+RSpec.describe GoalDueSoonNotificationJob, type: :job do
+  let(:user) { create(:user, email: "goal-job@example.com") }
+  let(:category) { create(:category, user: user) }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  it "sends email when goal is active and due soon" do
+    goal = create(:goal, :due_soon, user: user, category: category, status: "active")
+
+    expect {
+      described_class.perform_now(goal.id)
+    }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.to).to contain_exactly(user.email)
+    expect(email.subject).to include("Goal due soon")
+    expect(email.body.encoded).to include(goal.title)
+  end
+
+  it "does not send email when goal is not due soon" do
+    goal = create(:goal, user: user, category: category, target_date: 1.month.from_now)
+
+    expect {
+      described_class.perform_now(goal.id)
+    }.not_to change(ActionMailer::Base.deliveries, :count)
+  end
+end

--- a/spec/jobs/monthly_financial_report_job_spec.rb
+++ b/spec/jobs/monthly_financial_report_job_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe MonthlyFinancialReportJob, type: :job do
+  let(:user) { create(:user, email: "reports-job@example.com") }
+  let(:income_category) { create(:category, user: user, name: "Salary") }
+  let(:expense_category) { create(:category, user: user, name: "Food") }
+
+  before do
+    ActionMailer::Base.deliveries.clear
+  end
+
+  it "sends a monthly report email with summary values" do
+    create(:transaction, :income, user: user, category: income_category, amount: 2500, date: Date.new(2026, 3, 5))
+    create(:transaction, :expense, user: user, category: expense_category, amount: 700, date: Date.new(2026, 3, 10))
+
+    expect {
+      described_class.perform_now(user.id, "2026-03-01")
+    }.to change(ActionMailer::Base.deliveries, :count).by(1)
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.to).to contain_exactly(user.email)
+    expect(email.subject).to include("2026-03")
+    expect(email.body.encoded).to include("Income: $2,500.00")
+    expect(email.body.encoded).to include("Expenses: $700.00")
+    expect(email.body.encoded).to include("Balance: $1,800.00")
+  end
+
+  it "falls back to previous month when reference month is invalid" do
+    allow(Date).to receive(:current).and_return(Date.new(2026, 4, 20))
+
+    create(:transaction, :income, user: user, category: income_category, amount: 1200, date: Date.new(2026, 3, 8))
+
+    described_class.perform_now(user.id, "invalid-date")
+
+    email = ActionMailer::Base.deliveries.last
+    expect(email.subject).to include("2026-03")
+  end
+end

--- a/spec/requests/jobs_monitoring_spec.rb
+++ b/spec/requests/jobs_monitoring_spec.rb
@@ -1,0 +1,29 @@
+require "rails_helper"
+
+RSpec.describe "Jobs monitoring", type: :request do
+  let(:user) { create(:user) }
+
+  it "redirects unauthenticated users" do
+    get "/jobs/monitoring"
+
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it "renders snapshot for authenticated users" do
+    sign_in user
+    allow_any_instance_of(Jobs::MonitoringSnapshot).to receive(:call).and_return(
+      pending: 3,
+      running: 1,
+      failed: 0,
+      finished: 12
+    )
+
+    get "/jobs/monitoring"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Jobs Monitoring")
+    expect(response.body).to include("Pending")
+    expect(response.body).to include("Running")
+    expect(response.body).to include("Finished")
+  end
+end

--- a/spec/services/reports/monthly_summary_spec.rb
+++ b/spec/services/reports/monthly_summary_spec.rb
@@ -1,0 +1,20 @@
+require "rails_helper"
+
+RSpec.describe Reports::MonthlySummary, type: :service do
+  let(:user) { create(:user) }
+  let(:income_category) { create(:category, user: user, name: "Salary") }
+  let(:expense_category) { create(:category, user: user, name: "Food") }
+
+  it "returns monthly totals scoped by user and month" do
+    create(:transaction, :income, user: user, category: income_category, amount: 3000, date: Date.new(2026, 3, 2))
+    create(:transaction, :expense, user: user, category: expense_category, amount: 1250, date: Date.new(2026, 3, 12))
+    create(:transaction, :income, user: user, category: income_category, amount: 9999, date: Date.new(2026, 2, 1))
+
+    summary = described_class.new(user: user, reference_date: Date.new(2026, 3, 1)).call
+
+    expect(summary[:month]).to eq("2026-03")
+    expect(summary[:income]).to eq(3000)
+    expect(summary[:expenses]).to eq(1250)
+    expect(summary[:balance]).to eq(1750)
+  end
+end


### PR DESCRIPTION
## Summary
- install and configure Solid Queue runtime artifacts for production
- add recurring schedules for due-soon goal notifications and monthly financial reports
- implement background jobs to enqueue and deliver notifications/reports
- add mailers and templates for goal reminders and monthly summaries
- add authenticated jobs monitoring endpoint with Solid Queue snapshot

## Test Coverage
- add job specs for notification and report pipelines
- add service spec for monthly summary calculations
- add request spec for jobs monitoring access and rendering

## Validation
- RSpec: 55 examples, 0 failures
- Rubocop: 85 files inspected, 0 offenses
- Brakeman: 0 warnings
