### PR TITLE
refactor: extract dashboard query objects and enforce currency contract

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -5,7 +5,7 @@ class DashboardController < ApplicationController
   def index
     @user = Current.user
     @transactions = filtered_transactions
-    @export_transactions = chart_transactions.ordered
+    @export_transactions = filtered_chart_transactions.ordered
 
     # Goals data
     @goals = Current.user.goals.includes(:category).ordered
@@ -17,9 +17,10 @@ class DashboardController < ApplicationController
       overdue: @goals.overdue.count
     }
 
-    @income_vs_expenses_data = income_vs_expenses_chart_data
-    @expenses_by_category_data = expenses_by_category_chart_data
-    @monthly_evolution_data = monthly_evolution_chart_data
+    charts_data = Dashboard::ChartsData.new(scope: filtered_chart_transactions).call
+    @income_vs_expenses_data = charts_data[:income_vs_expenses]
+    @expenses_by_category_data = charts_data[:expenses_by_category]
+    @monthly_evolution_data = Dashboard::MonthlyEvolutionData.new(scope: unbounded_chart_transactions).call
 
     respond_to do |format|
       format.html
@@ -42,38 +43,19 @@ class DashboardController < ApplicationController
   private
 
   def filtered_transactions
-    @filtered_transactions ||= apply_filters(@user.transactions.includes(:category), include_date_filter: true)
-                               .ordered
-                               .page(params[:page])
-                               .per(20)
+    @filtered_transactions ||= filtered_chart_transactions.includes(:category).ordered.page(params[:page]).per(20)
   end
 
-  def chart_transactions
-    @chart_transactions ||= apply_filters(@user.transactions, include_date_filter: true)
+  def filtered_chart_transactions
+    @filtered_chart_transactions ||= transactions_filter.call(include_date_filter: true)
   end
 
-  def chart_transactions_without_date
-    @chart_transactions_without_date ||= apply_filters(@user.transactions, include_date_filter: false)
+  def unbounded_chart_transactions
+    @unbounded_chart_transactions ||= transactions_filter.call(include_date_filter: false)
   end
 
-  def income_vs_expenses_chart_data
-    totals = chart_transactions.group(:transaction_type).sum(:amount)
-
-    {
-      "Income" => totals.fetch("income", 0),
-      "Expenses" => totals.fetch("expense", 0)
-    }
-  end
-
-  def expenses_by_category_chart_data
-    chart_transactions.expense
-         .joins(:category)
-         .group("categories.name")
-         .sum(:amount)
-  end
-
-  def monthly_evolution_chart_data
-    Dashboard::MonthlyEvolutionData.new(scope: chart_transactions_without_date).call
+  def transactions_filter
+    @transactions_filter ||= Dashboard::TransactionsFilter.new(scope: @user.transactions, params: params)
   end
 
   def load_categories
@@ -89,35 +71,11 @@ class DashboardController < ApplicationController
       "dashboard/charts",
       @user.id,
       filter_cache_params,
-      @user.transactions.maximum(:updated_at)&.to_i
+      filtered_chart_transactions.maximum(:updated_at)&.to_i
     ]
   end
 
   def filter_cache_params
     params.slice("transaction_type", "category_id", "search", "period", "start_date", "end_date").to_unsafe_h
-  end
-
-  def apply_filters(scope, include_date_filter:)
-    scope = scope.by_type(params[:transaction_type]) if params[:transaction_type].present?
-    scope = scope.by_category(params[:category_id]) if params[:category_id].present?
-    scope = scope.search_description(params[:search]) if params[:search].present?
-    return scope unless include_date_filter
-
-    case params[:period]
-    when "today"
-      scope.where(date: Date.current)
-    when "week"
-      scope.where(date: Date.current.beginning_of_week..Date.current.end_of_week)
-    when "month"
-      scope.by_month(Date.current)
-    when "custom"
-      if params[:start_date].present? && params[:end_date].present?
-        scope.by_date_range(params[:start_date], params[:end_date])
-      else
-        scope
-      end
-    else
-      scope
-    end
   end
 end

--- a/app/services/dashboard/charts_data.rb
+++ b/app/services/dashboard/charts_data.rb
@@ -1,0 +1,32 @@
+module Dashboard
+  class ChartsData
+    def initialize(scope:)
+      @scope = scope
+    end
+
+    def call
+      {
+        income_vs_expenses: income_vs_expenses,
+        expenses_by_category: expenses_by_category
+      }
+    end
+
+    private
+
+    def income_vs_expenses
+      totals = @scope.group(:transaction_type).sum(:amount)
+
+      {
+        "Income" => totals.fetch("income", 0),
+        "Expenses" => totals.fetch("expense", 0)
+      }
+    end
+
+    def expenses_by_category
+      @scope.expense
+            .joins(:category)
+            .group("categories.name")
+            .sum(:amount)
+    end
+  end
+end

--- a/app/services/dashboard/transactions_filter.rb
+++ b/app/services/dashboard/transactions_filter.rb
@@ -1,0 +1,41 @@
+module Dashboard
+  class TransactionsFilter
+    def initialize(scope:, params:)
+      @scope = scope
+      @params = params
+    end
+
+    def call(include_date_filter: true)
+      scoped = @scope
+      scoped = scoped.by_type(@params[:transaction_type]) if @params[:transaction_type].present?
+      scoped = scoped.by_category(@params[:category_id]) if @params[:category_id].present?
+      scoped = scoped.search_description(@params[:search]) if @params[:search].present?
+      return scoped unless include_date_filter
+
+      apply_period_filter(scoped)
+    end
+
+    private
+
+    def apply_period_filter(scope)
+      case @params[:period]
+      when "today"
+        scope.where(date: Date.current)
+      when "week"
+        scope.where(date: Date.current.beginning_of_week..Date.current.end_of_week)
+      when "month"
+        scope.by_month(Date.current)
+      when "custom"
+        custom_date_range_scope(scope)
+      else
+        scope
+      end
+    end
+
+    def custom_date_range_scope(scope)
+      return scope unless @params[:start_date].present? && @params[:end_date].present?
+
+      scope.by_date_range(@params[:start_date], @params[:end_date])
+    end
+  end
+end

--- a/spec/models/currency_format_contract_spec.rb
+++ b/spec/models/currency_format_contract_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "Currency format contract" do
+  it "keeps BRL currency defaults" do
+    formatted = ActionController::Base.helpers.number_to_currency(1234.56)
+
+    expect(formatted).to eq("R$ 1.234,56")
+  end
+
+  it "keeps negative BRL currency format" do
+    formatted = ActionController::Base.helpers.number_to_currency(-10)
+
+    expect(formatted).to eq("-R$ 10,00")
+  end
+end

--- a/spec/services/dashboard/charts_data_spec.rb
+++ b/spec/services/dashboard/charts_data_spec.rb
@@ -1,0 +1,26 @@
+require "rails_helper"
+
+RSpec.describe Dashboard::ChartsData, type: :service do
+  let(:user) { create(:user) }
+  let(:income_category) { create(:category, user: user, name: "Salary") }
+  let(:food_category) { create(:category, user: user, name: "Food") }
+
+  before do
+    create(:transaction, :income, user: user, category: income_category, amount: 3000, date: Date.current)
+    create(:transaction, :expense, user: user, category: food_category, amount: 500, date: Date.current)
+    create(:transaction, :expense, user: user, category: food_category, amount: 250, date: Date.current)
+  end
+
+  it "returns aggregated chart data" do
+    data = described_class.new(scope: user.transactions).call
+
+    expect(data[:income_vs_expenses]).to eq(
+      "Income" => 3000,
+      "Expenses" => 750
+    )
+
+    expect(data[:expenses_by_category]).to eq(
+      "Food" => 750
+    )
+  end
+end

--- a/spec/services/dashboard/transactions_filter_spec.rb
+++ b/spec/services/dashboard/transactions_filter_spec.rb
@@ -1,0 +1,49 @@
+require "rails_helper"
+
+RSpec.describe Dashboard::TransactionsFilter, type: :service do
+  let(:user) { create(:user) }
+  let(:income_category) { create(:category, user: user, name: "Salary") }
+  let(:expense_category) { create(:category, user: user, name: "Food") }
+
+  let!(:income_transaction) do
+    create(:transaction, :income, user: user, category: income_category, description: "Monthly salary", amount: 2000, date: Date.current)
+  end
+  let!(:expense_transaction) do
+    create(:transaction, :expense, user: user, category: expense_category, description: "Lunch", amount: 50, date: Date.current)
+  end
+  let!(:old_expense_transaction) do
+    create(:transaction, :expense, user: user, category: expense_category, description: "Old lunch", amount: 30, date: 2.months.ago)
+  end
+
+  it "filters by type" do
+    scope = described_class.new(scope: user.transactions, params: { transaction_type: "income" }).call
+
+    expect(scope).to contain_exactly(income_transaction)
+  end
+
+  it "filters by category" do
+    scope = described_class.new(scope: user.transactions, params: { category_id: expense_category.id }).call
+
+    expect(scope).to include(expense_transaction, old_expense_transaction)
+    expect(scope).not_to include(income_transaction)
+  end
+
+  it "filters by search" do
+    scope = described_class.new(scope: user.transactions, params: { search: "salary" }).call
+
+    expect(scope).to contain_exactly(income_transaction)
+  end
+
+  it "applies period filter when include_date_filter is true" do
+    scope = described_class.new(scope: user.transactions, params: { period: "month" }).call
+
+    expect(scope).to include(income_transaction, expense_transaction)
+    expect(scope).not_to include(old_expense_transaction)
+  end
+
+  it "ignores period filter when include_date_filter is false" do
+    scope = described_class.new(scope: user.transactions, params: { period: "month" }).call(include_date_filter: false)
+
+    expect(scope).to include(old_expense_transaction)
+  end
+end


### PR DESCRIPTION
## Summary
- extract dashboard filtering logic into `Dashboard::TransactionsFilter`
- extract dashboard chart aggregation logic into `Dashboard::ChartsData`
- simplify `DashboardController` by delegating query responsibilities to service objects
- add explicit currency format contract tests to preserve BRL output consistency

## Test Coverage
- add service specs for dashboard filtering and chart aggregation
- add model-level currency format contract specs

## Validation
- RSpec: 68 examples, 0 failures
- Rubocop: 0 offenses
- Brakeman: 0 warnings

## Notes
- Route deprecation warnings still appear around `devise_for` on Rails 8.1.x.
- This is currently an upstream Devise compatibility issue (project is on Devise 4.9.4), not app routing logic regression.
