### PR TITLE
chore: strengthen P1 quality tooling and request authorization tests

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -54,6 +54,9 @@ group :development, :test do
   # See https://guides.rubyonrails.org/debugging_rails_applications.html#debugging-with-the-debug-gem
   gem "debug", platforms: %i[ mri windows ], require: "debug/prelude"
 
+  # N+1 query detection
+  gem "bullet"
+
   # Static analysis for security vulnerabilities [https://brakemanscanner.org/]
   gem "brakeman", "~> 7.1.0", require: false
 

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -88,6 +88,9 @@ GEM
     brakeman (7.1.0)
       racc
     builder (3.3.0)
+    bullet (8.1.0)
+      activesupport (>= 3.0.0)
+      uniform_notifier (~> 1.11)
     capybara (3.40.0)
       addressable
       matrix
@@ -417,6 +420,7 @@ GEM
     unicode-display_width (3.1.4)
       unicode-emoji (~> 4.0, >= 4.0.4)
     unicode-emoji (4.0.4)
+    uniform_notifier (1.18.0)
     uri (1.1.1)
     useragent (0.16.11)
     warden (1.2.9)
@@ -447,6 +451,7 @@ PLATFORMS
 DEPENDENCIES
   bootsnap
   brakeman (~> 7.1.0)
+  bullet
   capybara
   chartkick
   database_cleaner-active_record (~> 2.2)

--- a/config/initializers/bullet.rb
+++ b/config/initializers/bullet.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+if defined?(Bullet)
+  Rails.application.configure do
+    config.after_initialize do
+      bullet_in_test = Rails.env.test? && ENV["ENABLE_BULLET_IN_TEST"] == "1"
+      Bullet.enable = Rails.env.development? || bullet_in_test
+
+      next unless Bullet.enable?
+
+      Bullet.rails_logger = true
+      Bullet.bullet_logger = true
+      Bullet.console = true if Rails.env.development?
+      Bullet.add_footer = true if Rails.env.development?
+      Bullet.raise = true if bullet_in_test
+    end
+  end
+end

--- a/spec/requests/dashboard_csv_export_spec.rb
+++ b/spec/requests/dashboard_csv_export_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Dashboard CSV export", type: :request do
   let(:other_category) { create(:category, user: other_user, name: "Other") }
 
   before do
-    sign_in user
+    sign_in_user(user)
 
     create(:transaction, :expense, user: user, category: food, amount: 25, description: "Coffee", date: Date.current)
     create(:transaction, :income, user: user, category: salary, amount: 2000, description: "Paycheck", date: Date.current)

--- a/spec/requests/jobs_monitoring_spec.rb
+++ b/spec/requests/jobs_monitoring_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe "Jobs monitoring", type: :request do
   end
 
   it "renders snapshot for authenticated users" do
-    sign_in user
+    sign_in_user(user)
     allow_any_instance_of(Jobs::MonitoringSnapshot).to receive(:call).and_return(
       pending: 3,
       running: 1,

--- a/spec/requests/transactions_authorization_spec.rb
+++ b/spec/requests/transactions_authorization_spec.rb
@@ -1,0 +1,53 @@
+require "rails_helper"
+
+RSpec.describe "Transactions authorization", type: :request do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+  let(:user_category) { create(:category, user: user) }
+  let(:other_category) { create(:category, user: other_user) }
+  let!(:own_transaction) { create(:transaction, user: user, category: user_category, description: "Own tx") }
+  let!(:other_transaction) { create(:transaction, user: other_user, category: other_category, description: "Other tx") }
+
+  it "redirects unauthenticated access to transactions index" do
+    get "/transactions"
+
+    expect(response).to redirect_to(new_user_session_path)
+  end
+
+  it "returns not found when accessing another user's transaction" do
+    sign_in_user(user)
+
+    get "/transactions/#{other_transaction.id}"
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "returns not found when updating another user's transaction" do
+    sign_in_user(user)
+
+    patch "/transactions/#{other_transaction.id}", params: {
+      transaction: {
+        description: "Attempted update"
+      }
+    }
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "returns not found when deleting another user's transaction" do
+    sign_in_user(user)
+
+    delete "/transactions/#{other_transaction.id}"
+
+    expect(response).to have_http_status(:not_found)
+  end
+
+  it "allows access to edit own transaction" do
+    sign_in_user(user)
+
+    get "/transactions/#{own_transaction.id}/edit"
+
+    expect(response).to have_http_status(:ok)
+    expect(response.body).to include("Edit")
+  end
+end

--- a/spec/requests/transactions_pagination_spec.rb
+++ b/spec/requests/transactions_pagination_spec.rb
@@ -5,12 +5,7 @@ RSpec.describe "Transactions pagination", type: :request do
   let(:category) { create(:category, user: user, name: "General") }
 
   before do
-    post user_session_path, params: {
-      user: {
-        email: user.email,
-        password: "password123"
-      }
-    }
+    sign_in_user(user)
 
     25.times do |i|
       create(

--- a/spec/support/auth_helpers.rb
+++ b/spec/support/auth_helpers.rb
@@ -1,8 +1,22 @@
 module AuthHelpers
   def sign_in_user(user = nil)
     user ||= create(:user)
-    Current.user = user
+
+    post user_session_path, params: {
+      user: {
+        email: user.email,
+        password: "password123"
+      }
+    }
+
     user
+  end
+
+  def sign_out_user
+    delete destroy_user_session_path
+  rescue StandardError
+    # No-op helper for specs that do not establish a session.
+    nil
   end
 end
 


### PR DESCRIPTION
## Summary
- add Bullet in development/test to detect N+1 problems early
- configure Bullet initializer with safe defaults in development and opt-in strict mode in test (`ENABLE_BULLET_IN_TEST=1`)
- standardize request authentication helper through Devise session endpoint

## Test Coverage
- add request specs for transactions authorization and data isolation scenarios
- migrate existing request specs to shared auth helper (`sign_in_user`)

## Validation
- RSpec: 73 examples, 0 failures
- Rubocop: 0 offenses
- Brakeman: 0 warnings
