### PR TITLE
feat: traduzir app para pt-BR (i18n completo por etapas)

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,10 +4,26 @@ class ApplicationController < ActionController::Base
   # Only allow modern browsers supporting webp images, web push, badges, import maps, CSS nesting, and CSS :has.
   allow_browser versions: :modern unless Rails.env.test?
 
+  before_action :set_locale
   before_action :authenticate_user!
   around_action :log_request_performance, if: :performance_logging_enabled?
 
+  def default_url_options
+    locale = I18n.locale
+    return {} if locale == I18n.default_locale
+
+    { locale: locale }
+  end
+
   private
+  def set_locale
+    if params[:locale].present? && I18n.available_locales.map(&:to_s).include?(params[:locale])
+      session[:locale] = params[:locale]
+    end
+
+    locale = session[:locale].presence || I18n.default_locale
+    I18n.locale = locale
+  end
 
   def performance_logging_enabled?
     Rails.env.development? && %w[dashboard transactions].include?(controller_name)

--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -8,44 +8,42 @@ class ApplicationController < ActionController::Base
   before_action :authenticate_user!
   around_action :log_request_performance, if: :performance_logging_enabled?
 
-  def default_url_options
-    locale = I18n.locale
-    return {} if locale == I18n.default_locale
-
-    { locale: locale }
-  end
-
   private
-  def set_locale
-    if params[:locale].present? && I18n.available_locales.map(&:to_s).include?(params[:locale])
-      session[:locale] = params[:locale]
+    def set_locale
+      I18n.locale = extract_locale_from_header || I18n.default_locale
     end
 
-    locale = session[:locale].presence || I18n.default_locale
-    I18n.locale = locale
-  end
+    def extract_locale_from_header
+      header = request.env["HTTP_ACCEPT_LANGUAGE"].to_s
 
-  def performance_logging_enabled?
-    Rails.env.development? && %w[dashboard transactions].include?(controller_name)
-  end
+      locales = header.scan(/[A-Za-z-]+/).map(&:downcase)
+      return :"pt-BR" if locales.any? { |locale| locale == "pt-br" || locale.start_with?("pt") }
+      return :en if locales.any? { |locale| locale.start_with?("en") }
 
-  def log_request_performance
-    started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
-    query_count = 0
-
-    callback = lambda do |_name, _started, _finished, _id, payload|
-      query_count += 1 if payload[:sql] !~ /SCHEMA/ && !payload[:cached]
+      nil
     end
 
-    ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
-      yield
+    def performance_logging_enabled?
+      Rails.env.development? && %w[dashboard transactions].include?(controller_name)
     end
 
-    duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round(2)
+    def log_request_performance
+      started_at = Process.clock_gettime(Process::CLOCK_MONOTONIC)
+      query_count = 0
 
-    Rails.logger.info(
-      "[perf] controller=#{controller_name} action=#{action_name} path=#{request.path} " \
-      "status=#{response.status} duration_ms=#{duration_ms} queries=#{query_count}"
-    )
-  end
+      callback = lambda do |_name, _started, _finished, _id, payload|
+        query_count += 1 if payload[:sql] !~ /SCHEMA/ && !payload[:cached]
+      end
+
+      ActiveSupport::Notifications.subscribed(callback, "sql.active_record") do
+        yield
+      end
+
+      duration_ms = ((Process.clock_gettime(Process::CLOCK_MONOTONIC) - started_at) * 1000).round(2)
+
+      Rails.logger.info(
+        "[perf] controller=#{controller_name} action=#{action_name} path=#{request.path} " \
+        "status=#{response.status} duration_ms=#{duration_ms} queries=#{query_count}"
+      )
+    end
 end

--- a/app/controllers/categories_controller.rb
+++ b/app/controllers/categories_controller.rb
@@ -24,7 +24,7 @@ class CategoriesController < ApplicationController
     if @category.save
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to categories_path, notice: "Category was successfully created." }
+        format.html { redirect_to categories_path, notice: t("notices.categories.created") }
       end
     else
       render :new, status: :unprocessable_entity
@@ -35,7 +35,7 @@ class CategoriesController < ApplicationController
     if @category.update(category_params)
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to categories_path, notice: "Category was successfully updated." }
+        format.html { redirect_to categories_path, notice: t("notices.categories.updated") }
       end
     else
       render :edit, status: :unprocessable_entity
@@ -46,7 +46,7 @@ class CategoriesController < ApplicationController
     if @category.destroy
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to categories_path, notice: "Category was successfully deleted." }
+        format.html { redirect_to categories_path, notice: t("notices.categories.deleted") }
       end
     else
       redirect_to categories_path, alert: @category.errors.full_messages.join(", ")

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -52,10 +52,10 @@ class GoalsController < ApplicationController
     if @goal.save
       respond_to do |format|
         format.turbo_stream {
-          flash.now[:notice] = "Goal created successfully"
+          flash.now[:notice] = t("notices.goals.created")
         }
         format.html {
-          redirect_to goals_path, notice: "Goal created successfully"
+          redirect_to goals_path, notice: t("notices.goals.created")
         }
       end
     else
@@ -77,10 +77,10 @@ class GoalsController < ApplicationController
     if @goal.update(goal_params)
       respond_to do |format|
         format.turbo_stream {
-          flash.now[:notice] = "Goal updated successfully"
+          flash.now[:notice] = t("notices.goals.updated")
         }
         format.html {
-          redirect_to goal_path(@goal), notice: "Goal updated successfully"
+          redirect_to goal_path(@goal), notice: t("notices.goals.updated")
         }
       end
     else
@@ -101,10 +101,10 @@ class GoalsController < ApplicationController
 
     respond_to do |format|
       format.turbo_stream {
-        flash.now[:notice] = "Goal deleted successfully"
+        flash.now[:notice] = t("notices.goals.deleted")
       }
       format.html {
-        redirect_to goals_path, notice: "Goal deleted successfully"
+        redirect_to goals_path, notice: t("notices.goals.deleted")
       }
     end
   end
@@ -135,7 +135,7 @@ class GoalsController < ApplicationController
           ]
         end
         format.html {
-          redirect_to goal_path(@goal), notice: "Goal progress updated successfully"
+          redirect_to goal_path(@goal), notice: t("notices.goals.progress_updated")
         }
       end
     else
@@ -144,7 +144,7 @@ class GoalsController < ApplicationController
           render turbo_stream: turbo_stream.update("goal_modal", partial: "update_progress_form", locals: { goal: @goal }), status: :unprocessable_entity
         }
         format.html {
-          redirect_to goal_path(@goal), alert: "Unable to update goal progress"
+          redirect_to goal_path(@goal), alert: t("notices.goals.progress_update_failed")
         }
       end
     end

--- a/app/controllers/transactions_controller.rb
+++ b/app/controllers/transactions_controller.rb
@@ -25,7 +25,7 @@ class TransactionsController < ApplicationController
     if @transaction.save
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to transactions_path, notice: "Transaction was successfully created." }
+        format.html { redirect_to transactions_path, notice: t("notices.transactions.created") }
       end
     else
       load_categories
@@ -37,7 +37,7 @@ class TransactionsController < ApplicationController
     if @transaction.update(transaction_params)
       respond_to do |format|
         format.turbo_stream
-        format.html { redirect_to transactions_path, notice: "Transaction was successfully updated." }
+        format.html { redirect_to transactions_path, notice: t("notices.transactions.updated") }
       end
     else
       load_categories
@@ -56,7 +56,7 @@ class TransactionsController < ApplicationController
           turbo_stream.update("balance_summary", partial: "shared/balance_summary", locals: { user: Current.user })
         ]
       end
-      format.html { redirect_to transactions_path, notice: "Transaction was successfully deleted." }
+      format.html { redirect_to transactions_path, notice: t("notices.transactions.deleted") }
     end
   end
 

--- a/app/helpers/application_helper.rb
+++ b/app/helpers/application_helper.rb
@@ -1,2 +1,12 @@
 module ApplicationHelper
+  def localized_date(date, format: :short)
+    return "" if date.blank?
+
+    I18n.l(date, format: format)
+  end
+
+  def currency_unit(strip: false)
+    unit = I18n.t("number.currency.format.unit", default: "")
+    strip ? unit.strip : unit
+  end
 end

--- a/app/views/categories/_category.html.erb
+++ b/app/views/categories/_category.html.erb
@@ -13,14 +13,14 @@
     <%= category.transactions.count %>
   </td>
   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-    <%= link_to "Edit", edit_category_path(category), 
+    <%= link_to t("common.actions.edit"), edit_category_path(category),
         class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300",
         data: { turbo_frame: "modal" } %>
-    <%= link_to "Delete", category_path(category), 
+    <%= link_to t("common.actions.delete"), category_path(category),
         class: "ml-4 text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300",
         data: { 
           turbo_method: :delete,
-          turbo_confirm: "Are you sure?"
+          turbo_confirm: t("common.confirmations.are_you_sure")
         } %>
   </td>
 </tr>

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -48,7 +48,7 @@
             <%= form.text_field :color, 
                 required: true,
                 class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm transition-colors duration-200",
-                placeholder: "#FF5733",
+                placeholder: t("categories.form.color_placeholder"),
                 data: { 
                   color_picker_target: "hexInput",
                   category_form_target: "colorInput",

--- a/app/views/categories/_form.html.erb
+++ b/app/views/categories/_form.html.erb
@@ -9,7 +9,7 @@
         </div>
         <div class="ml-3">
           <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
-            There were <%= pluralize(category.errors.count, "error") %> with your submission
+            <%= t("categories.form.errors", count: category.errors.count) %>
           </h3>
           <div class="mt-2 text-sm text-red-700 dark:text-red-300">
             <ul class="list-disc pl-5 space-y-1">
@@ -30,7 +30,7 @@
         <%= form.text_field :name, 
             required: true,
             class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm transition-colors duration-200",
-            placeholder: "e.g. Food, Transport, Salary",
+            placeholder: t("categories.form.name_placeholder"),
             data: { category_form_target: "nameInput" } %>
       </div>
     </div>
@@ -60,7 +60,7 @@
                style="background-color: <%= category.color || '#6B7280' %>"></div>
         </div>
       </div>
-      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400">Choose a color to identify this category</p>
+      <p class="mt-2 text-sm text-gray-500 dark:text-gray-400"><%= t("categories.form.color_hint") %></p>
     </div>
   </div>
 
@@ -68,7 +68,7 @@
     <button type="button" 
             class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 py-2 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
             data-action="click->modal#close">
-      Cancel
+      <%= t("categories.form.cancel") %>
     </button>
     <%= form.submit class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-all duration-200", 
         data: { category_form_target: "submitButton" } %>

--- a/app/views/categories/create.turbo_stream.erb
+++ b/app/views/categories/create.turbo_stream.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800 dark:text-green-200">
-          Category was successfully created.
+          <%= t("notices.categories.created") %>
         </p>
       </div>
       <div class="ml-auto pl-3">
@@ -21,7 +21,7 @@
           <button type="button" 
                   class="inline-flex rounded-md bg-green-50 dark:bg-green-900/20 p-1.5 text-green-500 hover:bg-green-100 dark:hover:bg-green-900/40 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:ring-offset-green-50 dark:focus:ring-offset-green-900/20"
                   data-action="click->flash#dismiss">
-            <span class="sr-only">Dismiss</span>
+            <span class="sr-only"><%= t("common.actions.dismiss") %></span>
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
             </svg>

--- a/app/views/categories/destroy.turbo_stream.erb
+++ b/app/views/categories/destroy.turbo_stream.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800">
-          Category was successfully deleted.
+          <%= t("notices.categories.deleted") %>
         </p>
       </div>
     </div>

--- a/app/views/categories/edit.html.erb
+++ b/app/views/categories/edit.html.erb
@@ -19,7 +19,7 @@
           <button type="button" 
                   class="rounded-md bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   data-action="click->modal#close">
-            <span class="sr-only">Close</span>
+            <span class="sr-only"><%= t("common.actions.close") %></span>
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -29,7 +29,7 @@
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
             <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
-              Edit Category
+              <%= t("categories.modal.edit_title") %>
             </h3>
             <div class="mt-6">
               <%= render "form", category: @category %>

--- a/app/views/categories/index.html.erb
+++ b/app/views/categories/index.html.erb
@@ -3,13 +3,13 @@
     <%= turbo_frame_tag "categories" do %>
       <div class="sm:flex sm:items-center">
         <div class="sm:flex-auto">
-          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Categories</h1>
+          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white"><%= t("categories.index.title") %></h1>
           <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
-            Manage your transaction categories
+            <%= t("categories.index.subtitle") %>
           </p>
         </div>
         <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-          <%= link_to "New category", new_category_path, 
+          <%= link_to t("categories.index.new_category"), new_category_path,
               class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 sm:w-auto",
               data: { turbo_frame: "modal" } %>
         </div>
@@ -23,16 +23,16 @@
                 <thead class="bg-gray-50 dark:bg-gray-800">
                   <tr>
                     <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white sm:pl-6">
-                      Name
+                      <%= t("categories.index.columns.name") %>
                     </th>
                     <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                      Color
+                      <%= t("categories.index.columns.color") %>
                     </th>
                     <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                      Transactions
+                      <%= t("categories.index.columns.transactions") %>
                     </th>
                     <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                      <span class="sr-only">Actions</span>
+                      <span class="sr-only"><%= t("categories.index.columns.actions") %></span>
                     </th>
                   </tr>
                 </thead>

--- a/app/views/categories/new.html.erb
+++ b/app/views/categories/new.html.erb
@@ -19,7 +19,7 @@
           <button type="button" 
                   class="rounded-md bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   data-action="click->modal#close">
-            <span class="sr-only">Close</span>
+            <span class="sr-only"><%= t("common.actions.close") %></span>
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -29,7 +29,7 @@
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
             <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
-              New Category
+              <%= t("categories.modal.new_title") %>
             </h3>
             <div class="mt-6">
               <%= render "form", category: @category %>

--- a/app/views/categories/update.turbo_stream.erb
+++ b/app/views/categories/update.turbo_stream.erb
@@ -12,7 +12,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800 dark:text-green-200">
-          Category was successfully updated.
+          <%= t("notices.categories.updated") %>
         </p>
       </div>
       <div class="ml-auto pl-3">
@@ -20,7 +20,7 @@
           <button type="button" 
                   class="inline-flex rounded-md bg-green-50 dark:bg-green-900/20 p-1.5 text-green-500 hover:bg-green-100 dark:hover:bg-green-900/40 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:ring-offset-green-50 dark:focus:ring-offset-green-900/20"
                   data-action="click->flash#dismiss">
-            <span class="sr-only">Dismiss</span>
+            <span class="sr-only"><%= t("common.actions.dismiss") %></span>
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
             </svg>

--- a/app/views/dashboard/_charts.html.erb
+++ b/app/views/dashboard/_charts.html.erb
@@ -1,26 +1,26 @@
 <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
   <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Income vs Expenses</h2>
+    <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.income_vs_expenses") %></h2>
     <%= bar_chart @income_vs_expenses_data, 
         colors: ["#10b981", "#ef4444"],
-        suffix: "$",
+        prefix: currency_unit,
         height: "200px" %>
   </div>
 
   <% if @expenses_by_category_data.any? %>
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Expenses by Category</h2>
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.expenses_by_category") %></h2>
       <%= pie_chart @expenses_by_category_data,
-          suffix: "$",
+          prefix: currency_unit,
           height: "200px" %>
     </div>
   <% end %>
 </div>
 
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-8">
-  <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Monthly Evolution</h2>
+  <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.monthly_evolution") %></h2>
   <%= line_chart @monthly_evolution_data,
       colors: ["#10b981", "#ef4444"],
-      suffix: "$",
+      prefix: currency_unit,
       height: "250px" %>
 </div>

--- a/app/views/dashboard/_charts_and_transactions.html.erb
+++ b/app/views/dashboard/_charts_and_transactions.html.erb
@@ -3,7 +3,7 @@
     <!-- Charts Section -->
     <div class="grid grid-cols-1 lg:grid-cols-2 gap-6 mb-8">
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Income vs Expenses</h2>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.income_vs_expenses") %></h2>
         <%= bar_chart @income_vs_expenses_data,
             colors: ["#10b981", "#ef4444"],
             prefix: "R$ ",
@@ -12,7 +12,7 @@
 
       <% if @expenses_by_category_data.any? %>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Expenses by Category</h2>
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.expenses_by_category") %></h2>
           <%= pie_chart @expenses_by_category_data,
               prefix: "R$ ",
               height: "200px" %>
@@ -21,7 +21,7 @@
     </div>
 
     <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6 mb-8">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Monthly Evolution</h2>
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.monthly_evolution") %></h2>
       <%= line_chart @monthly_evolution_data,
           colors: ["#10b981", "#ef4444"],
           prefix: "R$ ",
@@ -38,19 +38,19 @@
               <thead class="bg-gray-50 dark:bg-gray-800">
                 <tr>
                   <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white sm:pl-6">
-                    Date
+                    <%= t("transactions.index.columns.date") %>
                   </th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                    Description
+                    <%= t("transactions.index.columns.transaction") %>
                   </th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                    Category
+                    <%= t("transactions.index.columns.category") %>
                   </th>
                   <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                    Amount
+                    <%= t("transactions.index.columns.amount") %>
                   </th>
                   <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                    <span class="sr-only">Actions</span>
+                    <span class="sr-only"><%= t("transactions.index.columns.actions") %></span>
                   </th>
                 </tr>
               </thead>
@@ -73,14 +73,14 @@
                       <%= transaction.formatted_amount %>
                     </td>
                     <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                      <%= link_to "Edit", edit_transaction_path(transaction), 
+                      <%= link_to t("common.actions.edit"), edit_transaction_path(transaction),
                           class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300",
                           data: { turbo_frame: "modal" } %>
-                      <%= link_to "Delete", transaction_path(transaction), 
+                      <%= link_to t("common.actions.delete"), transaction_path(transaction),
                           class: "ml-4 text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300",
                           data: { 
                             turbo_method: :delete,
-                            turbo_confirm: "Are you sure?"
+                            turbo_confirm: t("common.confirmations.are_you_sure")
                           } %>
                     </td>
                   </tr>
@@ -109,14 +109,14 @@
                     </div>
                   </div>
                   <div class="mt-2 flex space-x-3 text-xs">
-                    <%= link_to "Edit", edit_transaction_path(transaction), 
+                    <%= link_to t("common.actions.edit"), edit_transaction_path(transaction),
                         class: "text-indigo-600 dark:text-indigo-400",
                         data: { turbo_frame: "modal" } %>
-                    <%= link_to "Delete", transaction_path(transaction), 
+                    <%= link_to t("common.actions.delete"), transaction_path(transaction),
                         class: "text-red-600 dark:text-red-400",
                         data: { 
                           turbo_method: :delete,
-                          turbo_confirm: "Are you sure?"
+                          turbo_confirm: t("common.confirmations.are_you_sure")
                         } %>
                   </div>
                 </div>

--- a/app/views/dashboard/_charts_and_transactions.html.erb
+++ b/app/views/dashboard/_charts_and_transactions.html.erb
@@ -6,17 +6,17 @@
         <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.income_vs_expenses") %></h2>
         <%= bar_chart @income_vs_expenses_data,
             colors: ["#10b981", "#ef4444"],
-            prefix: "R$ ",
+            prefix: currency_unit,
             height: "200px" %>
       </div>
 
       <% if @expenses_by_category_data.any? %>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.expenses_by_category") %></h2>
-          <%= pie_chart @expenses_by_category_data,
-              prefix: "R$ ",
-              height: "200px" %>
-        </div>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.expenses_by_category") %></h2>
+        <%= pie_chart @expenses_by_category_data,
+            prefix: currency_unit,
+            height: "200px" %>
+      </div>
       <% end %>
     </div>
 
@@ -24,7 +24,7 @@
       <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("dashboard.charts.monthly_evolution") %></h2>
       <%= line_chart @monthly_evolution_data,
           colors: ["#10b981", "#ef4444"],
-          prefix: "R$ ",
+          prefix: currency_unit,
           height: "250px" %>
     </div>
   <% end %>
@@ -58,7 +58,7 @@
                 <% @transactions.each do |transaction| %>
                   <tr id="<%= dom_id(transaction) %>">
                     <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 dark:text-white sm:pl-6">
-                      <%= transaction.date.strftime("%b %d, %Y") %>
+                      <%= localized_date(transaction.date) %>
                     </td>
                     <td class="px-3 py-4 text-sm text-gray-900 dark:text-white">
                       <%= transaction.description %>
@@ -100,7 +100,7 @@
                         </p>
                       </div>
                       <div class="mt-1 flex items-center justify-between">
-                        <p class="text-xs text-gray-500 dark:text-gray-400"><%= transaction.date.strftime("%b %d, %Y") %></p>
+                        <p class="text-xs text-gray-500 dark:text-gray-400"><%= localized_date(transaction.date) %></p>
                         <span class="inline-flex items-center text-xs text-gray-500 dark:text-gray-400">
                           <span class="h-2 w-2 rounded-full mr-1" style="background-color: <%= transaction.category_color %>"></span>
                           <%= transaction.category_name %>

--- a/app/views/dashboard/_goals_summary.html.erb
+++ b/app/views/dashboard/_goals_summary.html.erb
@@ -92,7 +92,7 @@
               <!-- Due Date -->
               <div class="mt-2 flex items-center justify-between">
                 <div class="text-xs text-gray-500 dark:text-gray-400">
-                  <%= t("goals.summary.due") %>: <%= goal.target_date.strftime("%b %d, %Y") %>
+                  <%= t("goals.summary.due") %>: <%= localized_date(goal.target_date) %>
                 </div>
                 
                 <% if goal.overdue? %>

--- a/app/views/dashboard/_goals_summary.html.erb
+++ b/app/views/dashboard/_goals_summary.html.erb
@@ -1,8 +1,8 @@
 <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 mb-8">
   <div class="px-6 py-4 border-b border-gray-200 dark:border-gray-600">
     <div class="flex justify-between items-center">
-      <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Goals Overview</h2>
-      <%= link_to "View All Goals", goals_path, 
+      <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("goals.summary.overview") %></h2>
+      <%= link_to t("goals.summary.view_all"), goals_path,
           class: "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-sm font-medium transition-colors",
           data: { turbo_frame: "_top" } %>
     </div>
@@ -16,35 +16,35 @@
           <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">
             <%= @goals_stats[:total] %>
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">Total Goals</div>
+          <div class="text-sm text-gray-600 dark:text-gray-400"><%= t("goals.summary.total") %></div>
         </div>
         
         <div class="text-center">
           <div class="text-2xl font-bold text-green-600 dark:text-green-400">
             <%= @goals_stats[:active] %>
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">Active</div>
+          <div class="text-sm text-gray-600 dark:text-gray-400"><%= t("goals.status.active") %></div>
         </div>
         
         <div class="text-center">
           <div class="text-2xl font-bold text-purple-600 dark:text-purple-400">
             <%= @goals_stats[:completed] %>
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">Completed</div>
+          <div class="text-sm text-gray-600 dark:text-gray-400"><%= t("goals.status.completed") %></div>
         </div>
         
         <div class="text-center">
           <div class="text-2xl font-bold text-orange-600 dark:text-orange-400">
             <%= @goals_stats[:overdue] %>
           </div>
-          <div class="text-sm text-gray-600 dark:text-gray-400">Overdue</div>
+          <div class="text-sm text-gray-600 dark:text-gray-400"><%= t("goals.summary.overdue") %></div>
         </div>
       </div>
     </div>
 
     <!-- Recent Goals -->
     <div class="p-6">
-      <h3 class="text-md font-medium text-gray-900 dark:text-white mb-4">Recent Goals</h3>
+      <h3 class="text-md font-medium text-gray-900 dark:text-white mb-4"><%= t("goals.summary.recent") %></h3>
       
       <div class="space-y-4">
         <% @recent_goals.each do |goal| %>
@@ -60,12 +60,12 @@
                   
                   <!-- Goal Type Badge -->
                   <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-<%= goal.goal_type_color %>-100 text-<%= goal.goal_type_color %>-800 dark:bg-<%= goal.goal_type_color %>-800 dark:text-<%= goal.goal_type_color %>-100">
-                    <%= goal.goal_type.humanize %>
+                    <%= t("goals.types.#{goal.goal_type}") %>
                   </span>
                   
                   <!-- Status Badge -->
                   <span class="inline-flex items-center px-2 py-0.5 rounded text-xs font-medium bg-<%= goal.status_color %>-100 text-<%= goal.status_color %>-800 dark:bg-<%= goal.status_color %>-800 dark:text-<%= goal.status_color %>-100">
-                    <%= goal.status.humanize %>
+                    <%= t("goals.status.#{goal.status}") %>
                   </span>
                 </div>
                 
@@ -84,21 +84,21 @@
                 </div>
                 
                 <div class="text-xs text-gray-600 dark:text-gray-400 whitespace-nowrap">
-                  $<%= number_with_delimiter(goal.current_amount, delimiter: ",") %> / 
-                  $<%= number_with_delimiter(goal.target_amount, delimiter: ",") %>
+                  <%= number_to_currency(goal.current_amount) %> /
+                  <%= number_to_currency(goal.target_amount) %>
                 </div>
               </div>
               
               <!-- Due Date -->
               <div class="mt-2 flex items-center justify-between">
                 <div class="text-xs text-gray-500 dark:text-gray-400">
-                  Due: <%= goal.target_date.strftime("%b %d, %Y") %>
+                  <%= t("goals.summary.due") %>: <%= goal.target_date.strftime("%b %d, %Y") %>
                 </div>
                 
                 <% if goal.overdue? %>
-                  <span class="text-xs font-medium text-red-600 dark:text-red-400">Overdue</span>
+                  <span class="text-xs font-medium text-red-600 dark:text-red-400"><%= t("goals.summary.overdue") %></span>
                 <% elsif goal.due_soon? %>
-                  <span class="text-xs font-medium text-yellow-600 dark:text-yellow-400">Due Soon</span>
+                  <span class="text-xs font-medium text-yellow-600 dark:text-yellow-400"><%= t("goals.summary.due_soon") %></span>
                 <% end %>
               </div>
             </div>
@@ -108,7 +108,7 @@
       
       <!-- Quick Actions -->
       <div class="mt-6 flex justify-center">
-        <%= link_to "Add New Goal", new_goal_path, 
+        <%= link_to t("goals.summary.add_new"), new_goal_path,
             class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors",
             data: { turbo_frame: "goal_modal" } %>
       </div>
@@ -122,10 +122,10 @@
         </svg>
       </div>
       
-      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No Goals Yet</h3>
-      <p class="text-gray-600 dark:text-gray-400 mb-6">Start tracking your financial objectives by creating your first goal.</p>
+        <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2"><%= t("goals.summary.empty_title") %></h3>
+        <p class="text-gray-600 dark:text-gray-400 mb-6"><%= t("goals.summary.empty_subtitle") %></p>
       
-      <%= link_to "Create Your First Goal", new_goal_path, 
+        <%= link_to t("goals.summary.create_first"), new_goal_path,
           class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors",
           data: { turbo_frame: "goal_modal" } %>
     </div>

--- a/app/views/dashboard/_transactions.html.erb
+++ b/app/views/dashboard/_transactions.html.erb
@@ -6,19 +6,19 @@
           <thead class="bg-gray-50 dark:bg-gray-800">
             <tr>
               <th scope="col" class="py-3.5 pl-4 pr-3 text-left text-sm font-semibold text-gray-900 dark:text-white sm:pl-6">
-                Date
+                <%= t("transactions.index.columns.date") %>
               </th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                Description
+                <%= t("transactions.index.columns.transaction") %>
               </th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                Category
+                <%= t("transactions.index.columns.category") %>
               </th>
               <th scope="col" class="px-3 py-3.5 text-left text-sm font-semibold text-gray-900 dark:text-white">
-                Amount
+                <%= t("transactions.index.columns.amount") %>
               </th>
               <th scope="col" class="relative py-3.5 pl-3 pr-4 sm:pr-6">
-                <span class="sr-only">Actions</span>
+                <span class="sr-only"><%= t("transactions.index.columns.actions") %></span>
               </th>
             </tr>
           </thead>
@@ -26,7 +26,7 @@
             <% @transactions.each do |transaction| %>
               <tr id="<%= dom_id(transaction) %>">
                 <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 dark:text-white sm:pl-6">
-                  <%= transaction.date.strftime("%b %d, %Y") %>
+                  <%= localized_date(transaction.date) %>
                 </td>
                 <td class="px-3 py-4 text-sm text-gray-900 dark:text-white">
                   <%= transaction.description %>
@@ -41,14 +41,14 @@
                   <%= transaction.formatted_amount %>
                 </td>
                 <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-                  <%= link_to "Edit", edit_transaction_path(transaction), 
+                  <%= link_to t("common.actions.edit"), edit_transaction_path(transaction), 
                       class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300",
                       data: { turbo_frame: "modal" } %>
-                  <%= link_to "Delete", transaction_path(transaction), 
+                  <%= link_to t("common.actions.delete"), transaction_path(transaction), 
                       class: "ml-4 text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300",
                       data: { 
                         turbo_method: :delete,
-                        turbo_confirm: "Are you sure?"
+                        turbo_confirm: t("common.confirmations.are_you_sure")
                       } %>
                 </td>
               </tr>
@@ -68,7 +68,7 @@
                     </p>
                   </div>
                   <div class="mt-1 flex items-center justify-between">
-                    <p class="text-xs text-gray-500 dark:text-gray-400"><%= transaction.date.strftime("%b %d, %Y") %></p>
+                    <p class="text-xs text-gray-500 dark:text-gray-400"><%= localized_date(transaction.date) %></p>
                     <span class="inline-flex items-center text-xs text-gray-500 dark:text-gray-400">
                       <span class="h-2 w-2 rounded-full mr-1" style="background-color: <%= transaction.category_color %>"></span>
                       <%= transaction.category_name %>
@@ -77,14 +77,14 @@
                 </div>
               </div>
               <div class="mt-2 flex space-x-3 text-xs">
-                <%= link_to "Edit", edit_transaction_path(transaction), 
+                <%= link_to t("common.actions.edit"), edit_transaction_path(transaction), 
                     class: "text-indigo-600 dark:text-indigo-400",
                     data: { turbo_frame: "modal" } %>
-                <%= link_to "Delete", transaction_path(transaction), 
+                <%= link_to t("common.actions.delete"), transaction_path(transaction), 
                     class: "text-red-600 dark:text-red-400",
                     data: { 
                       turbo_method: :delete,
-                      turbo_confirm: "Are you sure?"
+                      turbo_confirm: t("common.confirmations.are_you_sure")
                     } %>
               </div>
             </div>

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -2,21 +2,21 @@
   <div class="mx-auto max-w-4xl">
     <div class="sm:flex sm:items-center">
       <div class="sm:flex-auto">
-        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Dashboard</h1>
+        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white"><%= t("dashboard.index.title") %></h1>
         <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
-          Financial overview and transaction management
+          <%= t("dashboard.index.subtitle") %>
         </p>
       </div>
       <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
         <div class="flex items-center gap-2">
-          <%= link_to "Export CSV",
+          <%= link_to t("dashboard.index.export_csv"),
               dashboard_path(
                 request.query_parameters.slice("transaction_type", "category_id", "search", "period", "start_date", "end_date").merge(format: :csv)
               ),
               class: "inline-flex items-center justify-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
               data: { turbo: false } %>
 
-          <%= link_to "New transaction", new_transaction_path,
+            <%= link_to t("dashboard.index.new_transaction"), new_transaction_path,
               class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
               data: { turbo_frame: "modal" } %>
         </div>
@@ -44,13 +44,13 @@
           } do |f| %>
         <div class="bg-white dark:bg-gray-800 shadow sm:rounded-lg">
           <div class="px-4 py-5 sm:p-6">
-            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white">Filters</h3>
+            <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white"><%= t("dashboard.index.filters.title") %></h3>
             
             <!-- Search field - full width on top -->
             <div class="mt-5">
-              <%= f.label :search, "Search Description", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+                <%= f.label :search, t("dashboard.index.filters.search_label"), class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
               <%= f.text_field :search, 
-                  placeholder: "Search transactions...",
+                  placeholder: t("dashboard.index.filters.search_placeholder"),
                   value: params[:search],
                   class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                   data: { action: "input->filters#submit" } %>
@@ -61,16 +61,16 @@
               <div>
                 <%= f.label :transaction_type, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.select :transaction_type, 
-                    options_for_select([["All", ""], ["Income", "income"], ["Expense", "expense"]], params[:transaction_type]),
+                  options_for_select([[t("dashboard.index.filters.all"), ""], [t("dashboard.index.filters.income"), "income"], [t("dashboard.index.filters.expense"), "expense"]], params[:transaction_type]),
                     {},
                     class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#submit" } %>
               </div>
               
               <div>
-                <%= f.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+                <%= f.label :category_id, t("dashboard.index.filters.category"), class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.select :category_id,
-                    options_for_select([["All Categories", ""]] + @categories.map { |c| [c.name, c.id] }, params[:category_id]),
+                  options_for_select([[t("dashboard.index.filters.all_categories"), ""]] + @categories.map { |c| [c.name, c.id] }, params[:category_id]),
                     {},
                     class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
                     data: { action: "change->filters#submit" } %>
@@ -80,11 +80,11 @@
                 <%= f.label :period, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
                 <%= f.select :period,
                     options_for_select([
-                      ["All time", ""],
-                      ["Today", "today"],
-                      ["This week", "week"],
-                      ["This month", "month"],
-                      ["Custom range", "custom"]
+                      [t("dashboard.index.filters.all_time"), ""],
+                      [t("dashboard.index.filters.today"), "today"],
+                      [t("dashboard.index.filters.this_week"), "week"],
+                      [t("dashboard.index.filters.this_month"), "month"],
+                      [t("dashboard.index.filters.custom_range"), "custom"]
                     ], params[:period]),
                     {},
                     class: "mt-1 block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
@@ -92,7 +92,7 @@
               </div>
               
               <div class="flex items-end">
-                <%= link_to "Clear filters", "#",
+                <%= link_to t("dashboard.index.filters.clear"), "#",
                   class: "inline-flex items-center rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 px-4 py-2 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800",
                   data: { action: "click->filters#clearForm" } %>
               </div>

--- a/app/views/devise/confirmations/new.html.erb
+++ b/app/views/devise/confirmations/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend confirmation instructions</h2>
+<h2><%= t("devise.views.confirmations.new.title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: confirmation_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend confirmation instructions" %>
+    <%= f.submit t("devise.views.confirmations.new.submit") %>
   </div>
 <% end %>
 

--- a/app/views/devise/mailer/confirmation_instructions.html.erb
+++ b/app/views/devise/mailer/confirmation_instructions.html.erb
@@ -1,5 +1,5 @@
-<p>Welcome <%= @email %>!</p>
+<p><%= t("devise.views.mailer.welcome", email: @email) %></p>
 
-<p>You can confirm your account email through the link below:</p>
+<p><%= t("devise.views.mailer.confirmation_instructions") %></p>
 
-<p><%= link_to 'Confirm my account', confirmation_url(@resource, confirmation_token: @token) %></p>
+<p><%= link_to t("devise.views.mailer.confirm_account"), confirmation_url(@resource, confirmation_token: @token) %></p>

--- a/app/views/devise/mailer/email_changed.html.erb
+++ b/app/views/devise/mailer/email_changed.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @email %>!</p>
+<p><%= t("devise.views.mailer.greeting", email: @email) %></p>
 
 <% if @resource.try(:unconfirmed_email?) %>
-  <p>We're contacting you to notify you that your email is being changed to <%= @resource.unconfirmed_email %>.</p>
+  <p><%= t("devise.views.mailer.email_changed_pending", email: @resource.unconfirmed_email) %></p>
 <% else %>
-  <p>We're contacting you to notify you that your email has been changed to <%= @resource.email %>.</p>
+  <p><%= t("devise.views.mailer.email_changed", email: @resource.email) %></p>
 <% end %>

--- a/app/views/devise/mailer/password_change.html.erb
+++ b/app/views/devise/mailer/password_change.html.erb
@@ -1,3 +1,3 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t("devise.views.mailer.greeting", email: @resource.email) %></p>
 
-<p>We're contacting you to notify you that your password has been changed.</p>
+<p><%= t("devise.views.mailer.password_changed") %></p>

--- a/app/views/devise/mailer/reset_password_instructions.html.erb
+++ b/app/views/devise/mailer/reset_password_instructions.html.erb
@@ -1,8 +1,8 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t("devise.views.mailer.greeting", email: @resource.email) %></p>
 
-<p>Someone has requested a link to change your password. You can do this through the link below.</p>
+<p><%= t("devise.views.mailer.reset_password_instructions") %></p>
 
-<p><%= link_to 'Change my password', edit_password_url(@resource, reset_password_token: @token) %></p>
+<p><%= link_to t("devise.views.mailer.change_password"), edit_password_url(@resource, reset_password_token: @token) %></p>
 
-<p>If you didn't request this, please ignore this email.</p>
-<p>Your password won't change until you access the link above and create a new one.</p>
+<p><%= t("devise.views.mailer.ignore_email") %></p>
+<p><%= t("devise.views.mailer.password_wont_change") %></p>

--- a/app/views/devise/mailer/unlock_instructions.html.erb
+++ b/app/views/devise/mailer/unlock_instructions.html.erb
@@ -1,7 +1,7 @@
-<p>Hello <%= @resource.email %>!</p>
+<p><%= t("devise.views.mailer.greeting", email: @resource.email) %></p>
 
-<p>Your account has been locked due to an excessive number of unsuccessful sign in attempts.</p>
+<p><%= t("devise.views.mailer.account_locked") %></p>
 
-<p>Click the link below to unlock your account:</p>
+<p><%= t("devise.views.mailer.unlock_instructions") %></p>
 
-<p><%= link_to 'Unlock my account', unlock_url(@resource, unlock_token: @token) %></p>
+<p><%= link_to t("devise.views.mailer.unlock_account"), unlock_url(@resource, unlock_token: @token) %></p>

--- a/app/views/devise/passwords/edit.html.erb
+++ b/app/views/devise/passwords/edit.html.erb
@@ -1,24 +1,24 @@
-<h2>Change your password</h2>
+<h2><%= t("devise.views.passwords.edit.title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
   <%= f.hidden_field :reset_password_token %>
 
   <div class="field">
-    <%= f.label :password, "New password" %><br />
+    <%= f.label :password, t("devise.views.passwords.edit.new_password") %><br />
     <% if @minimum_password_length %>
-      <em>(<%= @minimum_password_length %> characters minimum)</em><br />
+      <em><%= t("devise.views.passwords.edit.minimum_password_length", count: @minimum_password_length) %></em><br />
     <% end %>
     <%= f.password_field :password, autofocus: true, autocomplete: "new-password" %>
   </div>
 
   <div class="field">
-    <%= f.label :password_confirmation, "Confirm new password" %><br />
+    <%= f.label :password_confirmation, t("devise.views.passwords.edit.confirm_new_password") %><br />
     <%= f.password_field :password_confirmation, autocomplete: "new-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Change my password" %>
+    <%= f.submit t("devise.views.passwords.edit.submit") %>
   </div>
 <% end %>
 

--- a/app/views/devise/passwords/new.html.erb
+++ b/app/views/devise/passwords/new.html.erb
@@ -1,19 +1,19 @@
 <div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md">
     <div class="bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8">
-      <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white mb-8">Forgot your password?</h2>
+      <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white mb-8"><%= t("devise.views.passwords.new.title") %></h2>
       
       <%= form_for(resource, as: resource_name, url: password_path(resource_name), html: { method: :post }) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
         
         <div class="mb-5">
           <%= f.label :email, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "Enter your email address", 
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: t("devise.views.passwords.new.email_placeholder"),
               class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
         </div>
         
         <div class="flex items-center justify-between">
-          <%= f.submit "Send me reset password instructions", 
+            <%= f.submit t("devise.views.passwords.new.submit"),
               class: "text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" %>
         </div>
       <% end %>

--- a/app/views/devise/registrations/edit.html.erb
+++ b/app/views/devise/registrations/edit.html.erb
@@ -1,4 +1,4 @@
-<h2>Edit <%= resource_name.to_s.humanize %></h2>
+<h2><%= t("devise.views.registrations.edit.title", resource: resource_name.to_s.humanize) %></h2>
 
 <%= form_for(resource, as: resource_name, url: registration_path(resource_name), html: { method: :put }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,15 +9,15 @@
   </div>
 
   <% if devise_mapping.confirmable? && resource.pending_reconfirmation? %>
-    <div>Currently waiting confirmation for: <%= resource.unconfirmed_email %></div>
+    <div><%= t("devise.views.registrations.edit.waiting_confirmation", email: resource.unconfirmed_email) %></div>
   <% end %>
 
   <div class="field">
-    <%= f.label :password %> <i>(leave blank if you don't want to change it)</i><br />
+    <%= f.label :password %> <i><%= t("devise.views.registrations.edit.leave_blank") %></i><br />
     <%= f.password_field :password, autocomplete: "new-password" %>
     <% if @minimum_password_length %>
       <br />
-      <em><%= @minimum_password_length %> characters minimum</em>
+      <em><%= t("devise.views.registrations.new.minimum_password_length", count: @minimum_password_length) %></em>
     <% end %>
   </div>
 
@@ -27,17 +27,20 @@
   </div>
 
   <div class="field">
-    <%= f.label :current_password %> <i>(we need your current password to confirm your changes)</i><br />
+    <%= f.label :current_password %> <i><%= t("devise.views.registrations.edit.current_password_help") %></i><br />
     <%= f.password_field :current_password, autocomplete: "current-password" %>
   </div>
 
   <div class="actions">
-    <%= f.submit "Update" %>
+    <%= f.submit t("devise.views.registrations.edit.update") %>
   </div>
 <% end %>
 
-<h3>Cancel my account</h3>
+<h3><%= t("devise.views.registrations.edit.cancel_title") %></h3>
 
-<div>Unhappy? <%= button_to "Cancel my account", registration_path(resource_name), data: { confirm: "Are you sure?", turbo_confirm: "Are you sure?" }, method: :delete %></div>
+<div>
+  <%= t("devise.views.registrations.edit.unhappy") %>
+  <%= button_to t("devise.views.registrations.edit.cancel_account"), registration_path(resource_name), data: { confirm: t("devise.views.registrations.edit.confirm_cancel"), turbo_confirm: t("devise.views.registrations.edit.confirm_cancel") }, method: :delete %>
+</div>
 
-<%= link_to "Back", :back %>
+<%= link_to t("devise.views.registrations.edit.back"), :back %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -1,7 +1,7 @@
 <div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md">
     <div class="bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8">
-      <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white mb-8">Create your account</h2>
+      <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white mb-8"><%= t("devise.views.registrations.new.title") %></h2>
       
       <%= form_for(resource, as: resource_name, url: registration_path(resource_name)) do |f| %>
         <%= render "devise/shared/error_messages", resource: resource %>
@@ -14,21 +14,21 @@
 
         <div class="mb-5">
           <%= f.label :password, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
-          <%= f.password_field :password, autocomplete: "new-password", placeholder: "Create a password",
+          <%= f.password_field :password, autocomplete: "new-password", placeholder: t("devise.views.registrations.new.password_placeholder"),
               class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
           <% if @minimum_password_length %>
-            <p class="text-gray-600 dark:text-gray-400 text-xs mt-1">(<%= @minimum_password_length %> characters minimum)</p>
+            <p class="text-gray-600 dark:text-gray-400 text-xs mt-1"><%= t("devise.views.registrations.new.minimum_password_length", count: @minimum_password_length) %></p>
           <% end %>
         </div>
 
         <div class="mb-5">
           <%= f.label :password_confirmation, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
-          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: "Confirm your password",
+          <%= f.password_field :password_confirmation, autocomplete: "new-password", placeholder: t("devise.views.registrations.new.password_confirmation_placeholder"),
               class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
         </div>
 
         <div class="flex items-center justify-between">
-          <%= f.submit "Sign up",
+          <%= f.submit t("devise.views.registrations.new.submit"),
               class: "text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" %>
         </div>
       <% end %>

--- a/app/views/devise/registrations/new.html.erb
+++ b/app/views/devise/registrations/new.html.erb
@@ -8,7 +8,7 @@
         
         <div class="mb-5">
           <%= f.label :email, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "name@example.com",
+          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: t("devise.views.registrations.new.email_placeholder"),
               class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
         </div>
 

--- a/app/views/devise/sessions/new.html.erb
+++ b/app/views/devise/sessions/new.html.erb
@@ -1,17 +1,17 @@
 <div class="min-h-screen flex items-center justify-center py-12 px-4 sm:px-6 lg:px-8">
   <div class="w-full max-w-md">
     <div class="bg-white dark:bg-gray-800 shadow-md rounded px-8 pt-6 pb-8">
-      <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white mb-8">Sign in to Finance App</h2>
+      <h2 class="text-2xl font-bold text-center text-gray-800 dark:text-white mb-8"><%= t("devise.views.sessions.new.title") %></h2>
       
       <%= form_for(resource, as: resource_name, url: session_path(resource_name)) do |f| %>
         <div class="mb-5">
           <%= f.label :email, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
-          <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: "name@example.com", 
+            <%= f.email_field :email, autofocus: true, autocomplete: "email", placeholder: t("devise.views.sessions.new.email_placeholder"),
               class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
         </div>
         <div class="mb-5">
           <%= f.label :password, class: "block mb-2 text-sm font-medium text-gray-900 dark:text-white" %>
-          <%= f.password_field :password, autocomplete: "current-password", placeholder: "Enter your password",
+            <%= f.password_field :password, autocomplete: "current-password", placeholder: t("devise.views.sessions.new.password_placeholder"),
               class: "bg-gray-50 border border-gray-300 text-gray-900 text-sm rounded-lg focus:ring-blue-500 focus:border-blue-500 block w-full p-2.5 dark:bg-gray-700 dark:border-gray-600 dark:placeholder-gray-400 dark:text-white dark:focus:ring-blue-500 dark:focus:border-blue-500" %>
         </div>
         <% if devise_mapping.rememberable? %>
@@ -19,11 +19,11 @@
             <div class="flex items-center h-5">
               <%= f.check_box :remember_me, class: "w-4 h-4 border border-gray-300 rounded-sm bg-gray-50 focus:ring-3 focus:ring-blue-300 dark:bg-gray-700 dark:border-gray-600 dark:focus:ring-blue-600 dark:ring-offset-gray-800 dark:focus:ring-offset-gray-800" %>
             </div>
-            <%= f.label :remember_me, "Remember me", class: "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300" %>
+            <%= f.label :remember_me, t("devise.views.sessions.new.remember_me"), class: "ms-2 text-sm font-medium text-gray-900 dark:text-gray-300" %>
           </div>
         <% end %>
         <div class="flex items-center justify-between">
-          <%= f.submit "Sign in", 
+            <%= f.submit t("devise.views.sessions.new.submit"),
               class: "text-white bg-blue-600 hover:bg-blue-700 focus:ring-4 focus:outline-none focus:ring-blue-300 font-medium rounded-lg text-sm w-full px-5 py-2.5 text-center dark:bg-blue-600 dark:hover:bg-blue-700 dark:focus:ring-blue-800" %>
         </div>
       <% end %>

--- a/app/views/devise/shared/_links.html.erb
+++ b/app/views/devise/shared/_links.html.erb
@@ -1,25 +1,25 @@
 <%- if controller_name != 'sessions' %>
-  <%= link_to "Log in", new_session_path(resource_name), class: "text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline" %><br />
+  <%= link_to t("devise.views.shared.links.sign_in"), new_session_path(resource_name), class: "text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline" %><br />
 <% end %>
 
 <%- if devise_mapping.registerable? && controller_name != 'registrations' %>
-  <%= link_to "Sign up", new_registration_path(resource_name), class: "text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline" %><br />
+  <%= link_to t("devise.views.shared.links.sign_up"), new_registration_path(resource_name), class: "text-blue-500 hover:text-blue-700 dark:text-blue-400 dark:hover:text-blue-300 underline" %><br />
 <% end %>
 
 <%- if devise_mapping.recoverable? && controller_name != 'passwords' && controller_name != 'registrations' %>
-  <%= link_to "Forgot your password?", new_password_path(resource_name), class: "text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline text-sm" %><br />
+  <%= link_to t("devise.views.shared.links.forgot_password"), new_password_path(resource_name), class: "text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline text-sm" %><br />
 <% end %>
 
 <%- if devise_mapping.confirmable? && controller_name != 'confirmations' %>
-  <%= link_to "Didn't receive confirmation instructions?", new_confirmation_path(resource_name), class: "text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline text-sm" %><br />
+  <%= link_to t("devise.views.shared.links.confirmation_instructions"), new_confirmation_path(resource_name), class: "text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline text-sm" %><br />
 <% end %>
 
 <%- if devise_mapping.lockable? && resource_class.unlock_strategy_enabled?(:email) && controller_name != 'unlocks' %>
-  <%= link_to "Didn't receive unlock instructions?", new_unlock_path(resource_name), class: "text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline text-sm" %><br />
+  <%= link_to t("devise.views.shared.links.unlock_instructions"), new_unlock_path(resource_name), class: "text-gray-600 hover:text-gray-800 dark:text-gray-400 dark:hover:text-gray-200 underline text-sm" %><br />
 <% end %>
 
 <%- if devise_mapping.omniauthable? %>
   <%- resource_class.omniauth_providers.each do |provider| %>
-    <%= button_to "Sign in with #{OmniAuth::Utils.camelize(provider)}", omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded mt-2" %><br />
+    <%= button_to t("devise.views.shared.links.sign_in_with_provider", provider: OmniAuth::Utils.camelize(provider)), omniauth_authorize_path(resource_name, provider), data: { turbo: false }, class: "bg-gray-300 hover:bg-gray-400 text-gray-800 font-bold py-2 px-4 rounded mt-2" %><br />
   <% end %>
 <% end %>

--- a/app/views/devise/unlocks/new.html.erb
+++ b/app/views/devise/unlocks/new.html.erb
@@ -1,4 +1,4 @@
-<h2>Resend unlock instructions</h2>
+<h2><%= t("devise.views.unlocks.new.title") %></h2>
 
 <%= form_for(resource, as: resource_name, url: unlock_path(resource_name), html: { method: :post }) do |f| %>
   <%= render "devise/shared/error_messages", resource: resource %>
@@ -9,7 +9,7 @@
   </div>
 
   <div class="actions">
-    <%= f.submit "Resend unlock instructions" %>
+    <%= f.submit t("devise.views.unlocks.new.submit") %>
   </div>
 <% end %>
 

--- a/app/views/goal_notifications_mailer/due_soon.text.erb
+++ b/app/views/goal_notifications_mailer/due_soon.text.erb
@@ -1,8 +1,8 @@
-Hi <%= @user.email %>,
+<%= t("mailers.goal_notifications.due_soon.greeting", email: @user.email) %>
 
-Your goal "<%= @goal.title %>" is due in <%= @goal.days_remaining %> day(s).
-Current progress: <%= number_to_percentage(@goal.progress_percentage, precision: 0) %>
-Target amount: <%= number_to_currency(@goal.target_amount) %>
-Current amount: <%= number_to_currency(@goal.current_amount) %>
+<%= t("mailers.goal_notifications.due_soon.summary", title: @goal.title, days: @goal.days_remaining) %>
+<%= t("mailers.goal_notifications.due_soon.current_progress", progress: number_to_percentage(@goal.progress_percentage, precision: 0)) %>
+<%= t("mailers.goal_notifications.due_soon.target_amount", amount: number_to_currency(@goal.target_amount)) %>
+<%= t("mailers.goal_notifications.due_soon.current_amount", amount: number_to_currency(@goal.current_amount)) %>
 
-Keep going!
+<%= t("mailers.goal_notifications.due_soon.encouragement") %>

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -54,13 +54,13 @@
             <%= f.label :target_amount, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <div class="relative">
               <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">R$</span>
+                <span class="text-gray-500 dark:text-gray-400 sm:text-sm"><%= currency_unit(strip: true) %></span>
               </div>
               <%= f.number_field :target_amount, 
                   step: 0.01, 
                   min: 0.01,
                   class: "w-full pl-7 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white",
-                  placeholder: "10000.00" %>
+                  placeholder: t("goals.form.target_amount_placeholder") %>
             </div>
           </div>
 
@@ -69,13 +69,13 @@
             <%= f.label :current_amount, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <div class="relative">
               <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">R$</span>
+                <span class="text-gray-500 dark:text-gray-400 sm:text-sm"><%= currency_unit(strip: true) %></span>
               </div>
               <%= f.number_field :current_amount, 
                   step: 0.01, 
                   min: 0,
                   class: "w-full pl-7 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white",
-                  placeholder: "0.00" %>
+                  placeholder: t("goals.form.current_amount_placeholder") %>
             </div>
           </div>
         </div>

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -9,7 +9,7 @@
         </div>
         <div class="ml-3">
           <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
-            There were <%= pluralize(goal.errors.count, "error") %> with your submission
+            <%= t("goals.form.errors", count: goal.errors.count) %>
           </h3>
           <div class="mt-2 text-sm text-red-700 dark:text-red-300">
             <ul class="list-disc pl-5 space-y-1">
@@ -32,7 +32,7 @@
             <%= f.label :title, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <%= f.text_field :title, 
                 class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white",
-                placeholder: "e.g., Emergency Fund" %>
+              placeholder: t("goals.form.title_placeholder") %>
           </div>
 
           <!-- Goal Type -->
@@ -40,12 +40,12 @@
             <%= f.label :goal_type, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <%= f.select :goal_type, 
                 options_for_select([
-                  ['Savings', 'savings'],
-                  ['Expense Reduction', 'expense_reduction'],
-                  ['Income Increase', 'income_increase'],
-                  ['Debt Payoff', 'debt_payoff']
+                  [t("goals.types.savings"), "savings"],
+                  [t("goals.types.expense_reduction"), "expense_reduction"],
+                  [t("goals.types.income_increase"), "income_increase"],
+                  [t("goals.types.debt_payoff"), "debt_payoff"]
                 ], goal.goal_type),
-                { prompt: "Select goal type" },
+                { prompt: t("goals.form.goal_type_prompt") },
                 { class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white" } %>
           </div>
 
@@ -54,7 +54,7 @@
             <%= f.label :target_amount, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <div class="relative">
               <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">$</span>
+                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">R$</span>
               </div>
               <%= f.number_field :target_amount, 
                   step: 0.01, 
@@ -69,7 +69,7 @@
             <%= f.label :current_amount, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <div class="relative">
               <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">$</span>
+                <span class="text-gray-500 dark:text-gray-400 sm:text-sm">R$</span>
               </div>
               <%= f.number_field :current_amount, 
                   step: 0.01, 
@@ -95,10 +95,10 @@
             <%= f.label :status, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <%= f.select :status, 
                 options_for_select([
-                  ['Active', 'active'],
-                  ['Paused', 'paused'],
-                  ['Completed', 'completed'],
-                  ['Cancelled', 'cancelled']
+                  [t("goals.status.active"), "active"],
+                  [t("goals.status.paused"), "paused"],
+                  [t("goals.status.completed"), "completed"],
+                  [t("goals.status.cancelled"), "cancelled"]
                 ], goal.status),
                 {},
                 { class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white" } %>
@@ -106,10 +106,10 @@
 
           <!-- Category -->
           <div>
-            <%= f.label :category_id, "Category (Optional)", class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
+            <%= f.label :category_id, t("goals.form.category_optional"), class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
             <%= f.select :category_id, 
                 options_from_collection_for_select(@categories, :id, :name, goal.category_id),
-                { prompt: "Select category (optional)" },
+              { prompt: t("goals.form.category_prompt") },
                 { class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white" } %>
           </div>
         </div>
@@ -121,7 +121,7 @@
         <%= f.text_area :description, 
             rows: 4,
             class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-none",
-            placeholder: "Describe your goal and why it's important to you..." %>
+          placeholder: t("goals.form.description_placeholder") %>
       </div>
 
       <!-- Form Actions -->
@@ -129,9 +129,9 @@
         <button type="button" 
                 class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 py-2 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                 data-action="click->modal#close">
-          Cancel
+          <%= t("common.actions.cancel") %>
         </button>
-        <%= f.submit goal.persisted? ? "Update Goal" : "Create Goal", 
+        <%= f.submit goal.persisted? ? t("goals.form.update_goal") : t("goals.form.create_goal"),
             class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-all duration-200" %>
       </div>
   </div>

--- a/app/views/goals/_goal_card.html.erb
+++ b/app/views/goals/_goal_card.html.erb
@@ -16,12 +16,12 @@
       <div class="flex gap-2 ml-4">
         <!-- Goal Type Badge -->
         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-<%= goal.goal_type_color %>-100 text-<%= goal.goal_type_color %>-800 dark:bg-<%= goal.goal_type_color %>-800 dark:text-<%= goal.goal_type_color %>-100">
-          <%= goal.goal_type.humanize %>
+          <%= t("goals.types.#{goal.goal_type}") %>
         </span>
         
         <!-- Status Badge -->
         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-<%= goal.status_color %>-100 text-<%= goal.status_color %>-800 dark:bg-<%= goal.status_color %>-800 dark:text-<%= goal.status_color %>-100">
-          <%= goal.status.humanize %>
+          <%= t("goals.status.#{goal.status}") %>
         </span>
       </div>
     </div>
@@ -29,7 +29,7 @@
     <!-- Progress Section -->
     <div class="mb-4">
       <div class="flex justify-between items-center mb-2">
-        <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Progress</span>
+        <span class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("goals.card.progress") %></span>
         <span class="text-sm font-semibold text-gray-900 dark:text-white">
           <%= number_to_percentage(goal.progress_percentage, precision: 1) %>
         </span>
@@ -44,10 +44,10 @@
       <!-- Amount Info -->
       <div class="flex justify-between items-center mt-2 text-sm">
         <span class="text-gray-600 dark:text-gray-400">
-          $<%= number_with_delimiter(goal.current_amount, delimiter: ",") %>
+          <%= number_to_currency(goal.current_amount) %>
         </span>
         <span class="font-medium text-gray-900 dark:text-white">
-          $<%= number_with_delimiter(goal.target_amount, delimiter: ",") %>
+          <%= number_to_currency(goal.target_amount) %>
         </span>
       </div>
     </div>
@@ -55,27 +55,27 @@
     <!-- Date and Remaining Info -->
     <div class="space-y-2 mb-4">
       <div class="flex justify-between items-center text-sm">
-        <span class="text-gray-600 dark:text-gray-400">Target Date:</span>
+        <span class="text-gray-600 dark:text-gray-400"><%= t("goals.card.target_date") %></span>
         <span class="font-medium text-gray-900 dark:text-white">
           <%= goal.target_date.strftime("%b %d, %Y") %>
         </span>
       </div>
       
       <div class="flex justify-between items-center text-sm">
-        <span class="text-gray-600 dark:text-gray-400">Days Remaining:</span>
+        <span class="text-gray-600 dark:text-gray-400"><%= t("goals.card.days_remaining") %></span>
         <span class="font-medium <%= goal.overdue? ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white' %>">
           <% if goal.overdue? %>
-            Overdue
+            <%= t("goals.card.overdue") %>
           <% else %>
-            <%= goal.days_remaining %> days
+            <%= t("goals.card.days_count", count: goal.days_remaining) %>
           <% end %>
         </span>
       </div>
       
       <div class="flex justify-between items-center text-sm">
-        <span class="text-gray-600 dark:text-gray-400">Remaining:</span>
+        <span class="text-gray-600 dark:text-gray-400"><%= t("goals.card.remaining") %></span>
         <span class="font-medium text-gray-900 dark:text-white">
-          $<%= number_with_delimiter(goal.remaining_amount, delimiter: ",") %>
+          <%= number_to_currency(goal.remaining_amount) %>
         </span>
       </div>
     </div>
@@ -93,17 +93,17 @@
   <div class="px-6 py-4 bg-gray-50 dark:bg-gray-700/50 border-t border-gray-200 dark:border-gray-600 rounded-b-lg">
     <div class="flex justify-between items-center">
       <div class="flex gap-2">
-        <%= link_to "View", goal_path(goal), 
+        <%= link_to t("common.actions.view"), goal_path(goal),
             class: "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-sm font-medium transition-colors",
             data: { turbo_frame: "_top" } %>
         
-        <%= link_to "Edit", edit_goal_path(goal), 
+        <%= link_to t("common.actions.edit"), edit_goal_path(goal),
             class: "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm font-medium transition-colors",
             data: { turbo_frame: "goal_modal" } %>
       </div>
       
       <% unless goal.completed? %>
-        <%= link_to "Update Progress", update_progress_goal_path(goal),
+        <%= link_to t("goals.card.update_progress"), update_progress_goal_path(goal),
             class: "text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 text-sm font-medium transition-colors",
             data: { 
               turbo_frame: "goal_modal",

--- a/app/views/goals/_goal_card.html.erb
+++ b/app/views/goals/_goal_card.html.erb
@@ -57,7 +57,7 @@
       <div class="flex justify-between items-center text-sm">
         <span class="text-gray-600 dark:text-gray-400"><%= t("goals.card.target_date") %></span>
         <span class="font-medium text-gray-900 dark:text-white">
-          <%= goal.target_date.strftime("%b %d, %Y") %>
+          <%= localized_date(goal.target_date) %>
         </span>
       </div>
       

--- a/app/views/goals/_goals_list.html.erb
+++ b/app/views/goals/_goals_list.html.erb
@@ -15,8 +15,8 @@
         </svg>
       </div>
       
-      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2">No goals found</h3>
-      <p class="text-gray-600 dark:text-gray-400">Try adjusting your search or filters to find what you're looking for.</p>
+      <h3 class="text-lg font-medium text-gray-900 dark:text-white mb-2"><%= t("goals.list.empty_title") %></h3>
+      <p class="text-gray-600 dark:text-gray-400"><%= t("goals.list.empty_subtitle") %></p>
     </div>
   <% end %>
 </div>

--- a/app/views/goals/_update_progress_form.html.erb
+++ b/app/views/goals/_update_progress_form.html.erb
@@ -13,7 +13,7 @@
     <!-- Header -->
     <div class="flex justify-between items-center mb-4">
       <h3 class="text-lg font-semibold text-gray-900 dark:text-white">
-        Update Progress
+        <%= t("goals.progress_modal.title") %>
       </h3>
       
       <%= button_tag type: "button", 
@@ -31,8 +31,8 @@
         <%= goal.title %>
       </div>
       <div class="text-xs text-gray-600 dark:text-gray-400">
-        Current: $<%= number_with_delimiter(goal.current_amount) %> | 
-        Target: $<%= number_with_delimiter(goal.target_amount) %>
+        <%= t("goals.progress_modal.current") %>: <%= number_to_currency(goal.current_amount) %> |
+        <%= t("goals.progress_modal.target") %>: <%= number_to_currency(goal.target_amount) %>
       </div>
     </div>
 
@@ -43,12 +43,12 @@
         class: "space-y-4" do |f| %>
       
       <div>
-        <%= f.label :amount, "New Current Amount", 
+        <%= f.label :amount, t("goals.progress_modal.new_current_amount"),
             class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
         
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span class="text-gray-500 dark:text-gray-400 text-sm">$</span>
+            <span class="text-gray-500 dark:text-gray-400 text-sm">R$</span>
           </div>
           
           <%= f.number_field :amount, 
@@ -63,7 +63,7 @@
         </div>
         
         <div class="mt-1 text-xs text-gray-500 dark:text-gray-400">
-          Remaining: $<%= number_with_delimiter(goal.remaining_amount) %>
+          <%= t("goals.progress_modal.remaining") %>: <%= number_to_currency(goal.remaining_amount) %>
         </div>
       </div>
 
@@ -73,18 +73,18 @@
           <button type="button" 
                   class="px-3 py-1 text-xs bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
                   onclick="addQuickAmount(<%= amount %>)">
-            +$<%= amount %>
+            +R$<%= amount %>
           </button>
         <% end %>
       </div>
 
       <!-- Form Actions -->
       <div class="flex justify-end gap-3 pt-4 border-t border-gray-200 dark:border-gray-600">
-        <%= button_tag "Cancel", type: "button",
+        <%= button_tag t("common.actions.cancel"), type: "button",
             class: "px-4 py-2 bg-gray-300 hover:bg-gray-400 text-gray-700 font-medium rounded-lg transition-colors",
             data: { action: "click->modal#close" } %>
         
-        <%= f.submit "Update Progress", 
+        <%= f.submit t("goals.progress_modal.submit"),
             class: "px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors" %>
       </div>
     <% end %>

--- a/app/views/goals/_update_progress_form.html.erb
+++ b/app/views/goals/_update_progress_form.html.erb
@@ -48,7 +48,7 @@
         
         <div class="relative">
           <div class="absolute inset-y-0 left-0 pl-3 flex items-center pointer-events-none">
-            <span class="text-gray-500 dark:text-gray-400 text-sm">R$</span>
+            <span class="text-gray-500 dark:text-gray-400 text-sm"><%= currency_unit(strip: true) %></span>
           </div>
           
           <%= f.number_field :amount, 
@@ -58,7 +58,7 @@
               value: goal.current_amount,
               id: "goal_amount_field",
               class: "w-full pl-8 pr-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white",
-              placeholder: "0.00",
+              placeholder: t("goals.progress_modal.amount_placeholder"),
               required: true %>
         </div>
         
@@ -73,7 +73,7 @@
           <button type="button" 
                   class="px-3 py-1 text-xs bg-gray-100 dark:bg-gray-600 text-gray-700 dark:text-gray-300 rounded hover:bg-gray-200 dark:hover:bg-gray-500 transition-colors"
                   onclick="addQuickAmount(<%= amount %>)">
-            +R$<%= amount %>
+            <%= t("goals.progress_modal.quick_add", unit: currency_unit(strip: true), amount: amount) %>
           </button>
         <% end %>
       </div>

--- a/app/views/goals/create.turbo_stream.erb
+++ b/app/views/goals/create.turbo_stream.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800 dark:text-green-200">
-          Goal created successfully
+          <%= t("notices.goals.created") %>
         </p>
       </div>
       <div class="ml-auto pl-3">
@@ -26,7 +26,7 @@
           <button type="button" 
                   class="inline-flex rounded-md bg-green-50 dark:bg-green-900/20 p-1.5 text-green-500 hover:bg-green-100 dark:hover:bg-green-900/40 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:ring-offset-green-50 dark:focus:ring-offset-green-900/20"
                   data-action="click->flash#dismiss">
-            <span class="sr-only">Dismiss</span>
+            <span class="sr-only"><%= t("common.actions.dismiss") %></span>
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
             </svg>

--- a/app/views/goals/edit.html.erb
+++ b/app/views/goals/edit.html.erb
@@ -18,7 +18,7 @@
           <button type="button" 
                   class="rounded-md bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   data-action="click->modal#close">
-            <span class="sr-only">Close</span>
+            <span class="sr-only"><%= t("common.actions.close") %></span>
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -28,7 +28,7 @@
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
             <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
-              Edit Goal
+              <%= t("goals.modal.edit_title") %>
             </h3>
             <div class="mt-6">
               <%= render "form", goal: @goal %>

--- a/app/views/goals/index.html.erb
+++ b/app/views/goals/index.html.erb
@@ -2,13 +2,13 @@
   <div class="mx-auto max-w-6xl">
     <div class="sm:flex sm:items-center">
       <div class="sm:flex-auto">
-        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Goals</h1>
+        <h1 class="text-3xl font-semibold text-gray-900 dark:text-white"><%= t("goals.index.title") %></h1>
         <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
-          Track and manage your financial objectives
+          <%= t("goals.index.subtitle") %>
         </p>
       </div>
       <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-        <%= link_to "New goal", new_goal_path, 
+        <%= link_to t("goals.index.new_goal"), new_goal_path,
             class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
             data: { turbo_frame: "goal_modal" } %>
       </div>
@@ -26,7 +26,7 @@
           
           <div class="flex-1">
             <%= f.text_field :search, 
-                placeholder: "Search goals...", 
+                placeholder: t("goals.index.filters.search_placeholder"),
                 value: params[:search],
                 class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white",
                 data: { action: "input->filters#submit" } %>
@@ -35,11 +35,11 @@
           <div class="flex gap-2">
             <%= f.select :status, 
                 options_for_select([
-                  ['All Status', ''],
-                  ['Active', 'active'],
-                  ['Completed', 'completed'],
-                  ['Paused', 'paused'],
-                  ['Cancelled', 'cancelled']
+                  [t("goals.index.filters.all_status"), ""],
+                  [t("goals.status.active"), "active"],
+                  [t("goals.status.completed"), "completed"],
+                  [t("goals.status.paused"), "paused"],
+                  [t("goals.status.cancelled"), "cancelled"]
                 ], params[:status]),
                 {},
                 { class: "px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white",
@@ -47,11 +47,11 @@
 
             <%= f.select :goal_type,
                 options_for_select([
-                  ['All Types', ''],
-                  ['Savings', 'savings'],
-                  ['Expense Reduction', 'expense_reduction'],
-                  ['Income Increase', 'income_increase'],
-                  ['Debt Payoff', 'debt_payoff']
+                  [t("goals.index.filters.all_types"), ""],
+                  [t("goals.types.savings"), "savings"],
+                  [t("goals.types.expense_reduction"), "expense_reduction"],
+                  [t("goals.types.income_increase"), "income_increase"],
+                  [t("goals.types.debt_payoff"), "debt_payoff"]
                 ], params[:goal_type]),
                 {},
                 { class: "px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-indigo-500 focus:border-indigo-500 dark:bg-gray-700 dark:text-white",

--- a/app/views/goals/new.html.erb
+++ b/app/views/goals/new.html.erb
@@ -18,7 +18,7 @@
           <button type="button" 
                   class="rounded-md bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   data-action="click->modal#close">
-            <span class="sr-only">Close</span>
+            <span class="sr-only"><%= t("common.actions.close") %></span>
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -28,7 +28,7 @@
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
             <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
-              New Goal
+              <%= t("goals.modal.new_title") %>
             </h3>
             <div class="mt-6">
               <%= render "form", goal: @goal %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -117,7 +117,7 @@
           <div>
             <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.card.target_date") %></dt>
             <dd class="mt-1 text-sm text-gray-900 dark:text-white">
-              <%= @goal.target_date.strftime("%B %d, %Y") %>
+              <%= localized_date(@goal.target_date, format: :long) %>
             </dd>
           </div>
           
@@ -145,7 +145,7 @@
           <div>
             <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.show.created") %></dt>
             <dd class="mt-1 text-sm text-gray-900 dark:text-white">
-              <%= @goal.created_at.strftime("%B %d, %Y") %>
+              <%= localized_date(@goal.created_at.to_date, format: :long) %>
             </dd>
           </div>
         </div>
@@ -185,4 +185,3 @@
 <!-- Modal Frame -->
 <%= turbo_frame_tag "goal_modal" do %>
 <% end %>
-

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -14,21 +14,21 @@
         <div class="flex items-center gap-3 mt-2">
           <!-- Goal Type Badge -->
           <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-medium bg-<%= @goal.goal_type_color %>-100 text-<%= @goal.goal_type_color %>-800 dark:bg-<%= @goal.goal_type_color %>-800 dark:text-<%= @goal.goal_type_color %>-100">
-            <%= @goal.goal_type.humanize %>
+            <%= t("goals.types.#{@goal.goal_type}") %>
           </span>
           
           <!-- Status Badge -->
           <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-medium bg-<%= @goal.status_color %>-100 text-<%= @goal.status_color %>-800 dark:bg-<%= @goal.status_color %>-800 dark:text-<%= @goal.status_color %>-100">
-            <%= @goal.status.humanize %>
+            <%= t("goals.status.#{@goal.status}") %>
           </span>
 
           <% if @goal.overdue? %>
             <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100">
-              Overdue
+              <%= t("goals.card.overdue") %>
             </span>
           <% elsif @goal.due_soon? %>
             <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-medium bg-yellow-100 text-yellow-800 dark:bg-yellow-800 dark:text-yellow-100">
-              Due Soon
+              <%= t("goals.summary.due_soon") %>
             </span>
           <% end %>
         </div>
@@ -36,12 +36,12 @@
     </div>
     
     <div class="flex gap-3">
-      <%= link_to "Edit Goal", edit_goal_path(@goal), 
+      <%= link_to t("goals.show.edit_goal"), edit_goal_path(@goal),
           class: "inline-flex items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors",
           data: { turbo_frame: "goal_modal" } %>
       
       <% unless @goal.completed? %>
-        <%= link_to "Update Progress", update_progress_goal_path(@goal),
+        <%= link_to t("goals.show.update_progress"), update_progress_goal_path(@goal),
             class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors",
             data: { 
               turbo_frame: "goal_modal",
@@ -57,19 +57,19 @@
       <!-- Description -->
       <% if @goal.description.present? %>
         <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-          <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3">Description</h2>
+          <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-3"><%= t("goals.show.description") %></h2>
           <p class="text-gray-600 dark:text-gray-400 leading-relaxed"><%= simple_format(@goal.description) %></p>
         </div>
       <% end %>
 
       <!-- Progress Details -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Progress Details</h2>
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("goals.show.progress_details") %></h2>
         
         <!-- Large Progress Bar -->
         <div class="mb-6">
           <div class="flex justify-between items-center mb-2">
-            <span class="text-sm font-medium text-gray-700 dark:text-gray-300">Overall Progress</span>
+            <span class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("goals.show.overall_progress") %></span>
             <span class="text-lg font-bold text-gray-900 dark:text-white">
               <%= number_to_percentage(@goal.progress_percentage, precision: 1) %>
             </span>
@@ -85,23 +85,23 @@
         <div class="grid grid-cols-1 sm:grid-cols-3 gap-4">
           <div class="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
             <div class="text-2xl font-bold text-green-600 dark:text-green-400">
-              $<%= number_with_delimiter(@goal.current_amount, delimiter: ",") %>
+              <%= number_to_currency(@goal.current_amount) %>
             </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">Current Amount</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= t("goals.show.current_amount") %></div>
           </div>
           
           <div class="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
             <div class="text-2xl font-bold text-blue-600 dark:text-blue-400">
-              $<%= number_with_delimiter(@goal.target_amount, delimiter: ",") %>
+              <%= number_to_currency(@goal.target_amount) %>
             </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">Target Amount</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= t("goals.show.target_amount") %></div>
           </div>
           
           <div class="text-center p-4 bg-gray-50 dark:bg-gray-700/50 rounded-lg">
             <div class="text-2xl font-bold text-orange-600 dark:text-orange-400">
-              $<%= number_with_delimiter(@goal.remaining_amount, delimiter: ",") %>
+              <%= number_to_currency(@goal.remaining_amount) %>
             </div>
-            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1">Remaining</div>
+            <div class="text-sm text-gray-600 dark:text-gray-400 mt-1"><%= t("goals.card.remaining") %></div>
           </div>
         </div>
       </div>
@@ -111,30 +111,30 @@
     <div class="space-y-6">
       <!-- Goal Info -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Goal Information</h3>
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("goals.show.goal_information") %></h3>
         
         <div class="space-y-4">
           <div>
-            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Target Date</dt>
+            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.card.target_date") %></dt>
             <dd class="mt-1 text-sm text-gray-900 dark:text-white">
               <%= @goal.target_date.strftime("%B %d, %Y") %>
             </dd>
           </div>
           
           <div>
-            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Days Remaining</dt>
+            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.card.days_remaining") %></dt>
             <dd class="mt-1 text-sm <%= @goal.overdue? ? 'text-red-600 dark:text-red-400' : 'text-gray-900 dark:text-white' %>">
               <% if @goal.overdue? %>
-                Overdue by <%= (@goal.target_date - Date.current).abs.to_i %> days
+                <%= t("goals.show.overdue_by_days", count: (@goal.target_date - Date.current).abs.to_i) %>
               <% else %>
-                <%= @goal.days_remaining %> days
+                <%= t("goals.card.days_count", count: @goal.days_remaining) %>
               <% end %>
             </dd>
           </div>
           
           <% if @goal.category %>
             <div>
-              <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Category</dt>
+              <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("transactions.form.category") %></dt>
               <dd class="mt-1 flex items-center text-sm text-gray-900 dark:text-white">
                 <div class="w-3 h-3 rounded-full mr-2" style="background-color: <%= @goal.category.color %>"></div>
                 <%= @goal.category.name %>
@@ -143,7 +143,7 @@
           <% end %>
           
           <div>
-            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400">Created</dt>
+            <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.show.created") %></dt>
             <dd class="mt-1 text-sm text-gray-900 dark:text-white">
               <%= @goal.created_at.strftime("%B %d, %Y") %>
             </dd>
@@ -153,11 +153,11 @@
 
       <!-- Actions -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
-        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4">Actions</h3>
+        <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("common.actions.title") %></h3>
         
         <div class="space-y-3">
           <% unless @goal.completed? %>
-            <%= link_to "Update Progress", update_progress_goal_path(@goal),
+            <%= link_to t("goals.show.update_progress"), update_progress_goal_path(@goal),
                 class: "w-full inline-flex justify-center items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors",
                 data: { 
                   turbo_frame: "goal_modal",
@@ -165,16 +165,16 @@
                 } %>
           <% end %>
           
-          <%= link_to "Edit Goal", edit_goal_path(@goal), 
+          <%= link_to t("goals.show.edit_goal"), edit_goal_path(@goal),
               class: "w-full inline-flex justify-center items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors",
               data: { turbo_frame: "goal_modal" } %>
           
-          <%= link_to "Delete Goal", goal_path(@goal), 
+          <%= link_to t("goals.show.delete_goal"), goal_path(@goal),
               method: :delete,
               class: "w-full inline-flex justify-center items-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-medium rounded-lg transition-colors",
               data: { 
                 turbo_method: :delete,
-                turbo_confirm: "Are you sure you want to delete this goal? This action cannot be undone."
+                turbo_confirm: t("goals.show.delete_confirm")
               } %>
         </div>
       </div>

--- a/app/views/goals/update.turbo_stream.erb
+++ b/app/views/goals/update.turbo_stream.erb
@@ -18,7 +18,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800 dark:text-green-200">
-          Goal updated successfully
+          <%= t("notices.goals.updated") %>
         </p>
       </div>
       <div class="ml-auto pl-3">
@@ -26,7 +26,7 @@
           <button type="button" 
                   class="inline-flex rounded-md bg-green-50 dark:bg-green-900/20 p-1.5 text-green-500 hover:bg-green-100 dark:hover:bg-green-900/40 focus:outline-none focus:ring-2 focus:ring-green-600 focus:ring-offset-2 focus:ring-offset-green-50 dark:focus:ring-offset-green-900/20"
                   data-action="click->flash#dismiss">
-            <span class="sr-only">Dismiss</span>
+            <span class="sr-only"><%= t("common.actions.dismiss") %></span>
             <svg class="h-5 w-5" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
               <path d="M6.28 5.22a.75.75 0 00-1.06 1.06L8.94 10l-3.72 3.72a.75.75 0 101.06 1.06L10 11.06l3.72 3.72a.75.75 0 101.06-1.06L11.06 10l3.72-3.72a.75.75 0 00-1.06-1.06L10 8.94 6.28 5.22z" />
             </svg>

--- a/app/views/home/index.html.erb
+++ b/app/views/home/index.html.erb
@@ -1,15 +1,15 @@
 <div class="w-full">
   <div class="flex justify-between items-center mb-8">
-    <h1 class="font-bold text-4xl">Welcome to Finance App</h1>
+    <h1 class="font-bold text-4xl"><%= t("home.title") %></h1>
     <div class="flex items-center gap-4">
-      <span class="text-gray-600">Logged in as <%= current_user.email %></span>
-      <%= button_to "Sign out", destroy_user_session_path, method: :delete, 
+      <span class="text-gray-600"><%= t("home.logged_in_as") %> <%= current_user.email %></span>
+      <%= button_to t("app.nav.sign_out"), destroy_user_session_path, method: :delete,
           class: "bg-red-500 hover:bg-red-700 text-white font-bold py-2 px-4 rounded" %>
     </div>
   </div>
   
   <div class="bg-white shadow rounded-lg p-6">
-    <h2 class="text-2xl font-semibold mb-4">Dashboard</h2>
-    <p class="text-gray-600">Your financial dashboard will appear here.</p>
+    <h2 class="text-2xl font-semibold mb-4"><%= t("home.dashboard_title") %></h2>
+    <p class="text-gray-600"><%= t("home.dashboard_placeholder") %></p>
   </div>
 </div>

--- a/app/views/jobs/monitoring.html.erb
+++ b/app/views/jobs/monitoring.html.erb
@@ -1,27 +1,27 @@
 <div class="max-w-3xl mx-auto px-4 py-8">
   <div class="mb-6">
-    <h1 class="text-2xl font-bold text-gray-900">Jobs Monitoring</h1>
-    <p class="text-sm text-gray-600">Current background processing snapshot from Solid Queue.</p>
+    <h1 class="text-2xl font-bold text-gray-900"><%= t("jobs.monitoring.title") %></h1>
+    <p class="text-sm text-gray-600"><%= t("jobs.monitoring.subtitle") %></p>
   </div>
 
   <div class="grid grid-cols-1 sm:grid-cols-2 gap-4">
     <div class="rounded-lg border border-gray-200 p-4 bg-white">
-      <p class="text-sm text-gray-500">Pending</p>
+      <p class="text-sm text-gray-500"><%= t("jobs.monitoring.status.pending") %></p>
       <p class="text-2xl font-semibold text-gray-900"><%= @snapshot[:pending] %></p>
     </div>
 
     <div class="rounded-lg border border-gray-200 p-4 bg-white">
-      <p class="text-sm text-gray-500">Running</p>
+      <p class="text-sm text-gray-500"><%= t("jobs.monitoring.status.running") %></p>
       <p class="text-2xl font-semibold text-gray-900"><%= @snapshot[:running] %></p>
     </div>
 
     <div class="rounded-lg border border-gray-200 p-4 bg-white">
-      <p class="text-sm text-gray-500">Failed</p>
+      <p class="text-sm text-gray-500"><%= t("jobs.monitoring.status.failed") %></p>
       <p class="text-2xl font-semibold text-red-600"><%= @snapshot[:failed] %></p>
     </div>
 
     <div class="rounded-lg border border-gray-200 p-4 bg-white">
-      <p class="text-sm text-gray-500">Finished</p>
+      <p class="text-sm text-gray-500"><%= t("jobs.monitoring.status.finished") %></p>
       <p class="text-2xl font-semibold text-emerald-600"><%= @snapshot[:finished] %></p>
     </div>
   </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
 <html data-controller="theme">
   <head>
-    <title><%= content_for(:title) || "Finance App" %></title>
+    <title><%= content_for(:title) || t("app.name") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <meta name="apple-mobile-web-app-capable" content="yes">
     <meta name="mobile-web-app-capable" content="yes">
@@ -39,16 +39,16 @@
           <div class="flex h-16 justify-between">
             <div class="flex">
               <div class="flex flex-shrink-0 items-center">
-                <h1 class="text-xl font-semibold text-gray-900 dark:text-white">Finance App</h1>
+                <h1 class="text-xl font-semibold text-gray-900 dark:text-white"><%= t("app.name") %></h1>
               </div>
               <div class="hidden sm:ml-6 sm:flex sm:space-x-8">
-                <%= link_to "Dashboard", dashboard_path, 
+                <%= link_to t("app.nav.dashboard"), dashboard_path,
                     class: "inline-flex items-center border-b-2 #{current_page?(dashboard_path) ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'} px-1 pt-1 text-sm font-medium transition-theme" %>
-                <%= link_to "Transactions", transactions_path, 
+                <%= link_to t("app.nav.transactions"), transactions_path,
                     class: "inline-flex items-center border-b-2 #{current_page?(transactions_path) ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'} px-1 pt-1 text-sm font-medium transition-theme" %>
-                <%= link_to "Goals", goals_path,
+                <%= link_to t("app.nav.goals"), goals_path,
                     class: "inline-flex items-center border-b-2 #{current_page?(goals_path) ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'} px-1 pt-1 text-sm font-medium transition-theme" %>
-                <%= link_to "Categories", categories_path,
+                <%= link_to t("app.nav.categories"), categories_path,
                     class: "inline-flex items-center border-b-2 #{current_page?(categories_path) ? 'border-indigo-500 text-gray-900 dark:text-white' : 'border-transparent text-gray-500 hover:text-gray-700 dark:text-gray-300 dark:hover:text-white'} px-1 pt-1 text-sm font-medium transition-theme" %>
               </div>
             </div>
@@ -77,7 +77,7 @@
                 </button>
               </div>
               
-              <%= button_to "Sign out", destroy_user_session_path, method: :delete,
+                <%= button_to t("app.nav.sign_out"), destroy_user_session_path, method: :delete,
                   class: "text-sm text-gray-500 hover:text-gray-700 dark:text-gray-400 dark:hover:text-white" %>
             </div>
           </div>
@@ -86,13 +86,13 @@
         <!-- Mobile menu -->
         <div class="sm:hidden" data-mobile-menu-target="menu" style="display: none;">
           <div class="space-y-1 pb-3 pt-2">
-            <%= link_to "Dashboard", dashboard_path,
+            <%= link_to t("app.nav.dashboard"), dashboard_path,
                 class: "#{current_page?(dashboard_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
-            <%= link_to "Transactions", transactions_path,
+            <%= link_to t("app.nav.transactions"), transactions_path,
                 class: "#{current_page?(transactions_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
-            <%= link_to "Goals", goals_path,
+            <%= link_to t("app.nav.goals"), goals_path,
                 class: "#{current_page?(goals_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
-            <%= link_to "Categories", categories_path,
+            <%= link_to t("app.nav.categories"), categories_path,
                 class: "#{current_page?(categories_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
           </div>
           <div class="border-t border-gray-200 dark:border-gray-700 pb-3 pt-4">
@@ -100,7 +100,7 @@
               <div class="text-base font-medium text-gray-800 dark:text-white"><%= current_user.email %></div>
             </div>
             <div class="mt-3 space-y-1">
-              <%= button_to "Sign out", destroy_user_session_path, method: :delete,
+                <%= button_to t("app.nav.sign_out"), destroy_user_session_path, method: :delete,
                   class: "block px-4 py-2 text-base font-medium text-gray-500 hover:bg-gray-100 hover:text-gray-800 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white w-full text-left" %>
             </div>
           </div>

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -61,13 +61,6 @@
               </button>
             </div>
             <div class="hidden sm:flex items-center space-x-4">
-              <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-                <span class="uppercase"><%= t("app.nav.language") %></span>
-                <%= link_to t("app.nav.locale.en"), url_for(locale: :en),
-                    class: "#{I18n.locale.to_s == 'en' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
-                <%= link_to t("app.nav.locale.pt_br"), url_for(locale: :'pt-BR'),
-                    class: "#{I18n.locale.to_s == 'pt-BR' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
-              </div>
               <!-- Theme Toggle -->
               <button type="button"
                       data-action="click->theme#toggle"
@@ -101,15 +94,6 @@
                 class: "#{current_page?(goals_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
             <%= link_to t("app.nav.categories"), categories_path,
                 class: "#{current_page?(categories_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
-          </div>
-          <div class="border-t border-gray-200 dark:border-gray-700 py-2 px-4 text-xs text-gray-500 dark:text-gray-400">
-            <span class="uppercase"><%= t("app.nav.language") %></span>
-            <div class="mt-2 flex gap-3">
-              <%= link_to t("app.nav.locale.en"), url_for(locale: :en),
-                  class: "#{I18n.locale.to_s == 'en' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
-              <%= link_to t("app.nav.locale.pt_br"), url_for(locale: :'pt-BR'),
-                  class: "#{I18n.locale.to_s == 'pt-BR' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
-            </div>
           </div>
           <div class="border-t border-gray-200 dark:border-gray-700 pb-3 pt-4">
             <div class="flex items-center px-4">

--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html data-controller="theme">
+<html data-controller="theme" lang="<%= I18n.locale %>">
   <head>
     <title><%= content_for(:title) || t("app.name") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
@@ -61,6 +61,13 @@
               </button>
             </div>
             <div class="hidden sm:flex items-center space-x-4">
+              <div class="flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+                <span class="uppercase"><%= t("app.nav.language") %></span>
+                <%= link_to t("app.nav.locale.en"), url_for(locale: :en),
+                    class: "#{I18n.locale.to_s == 'en' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
+                <%= link_to t("app.nav.locale.pt_br"), url_for(locale: :'pt-BR'),
+                    class: "#{I18n.locale.to_s == 'pt-BR' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
+              </div>
               <!-- Theme Toggle -->
               <button type="button"
                       data-action="click->theme#toggle"
@@ -94,6 +101,15 @@
                 class: "#{current_page?(goals_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
             <%= link_to t("app.nav.categories"), categories_path,
                 class: "#{current_page?(categories_path) ? 'border-indigo-500 bg-indigo-50 text-indigo-700 dark:bg-indigo-900 dark:text-indigo-200' : 'border-transparent text-gray-500 hover:border-gray-300 hover:bg-gray-50 hover:text-gray-700 dark:text-gray-300 dark:hover:bg-gray-700 dark:hover:text-white'} block border-l-4 py-2 pl-3 pr-4 text-base font-medium transition-theme" %>
+          </div>
+          <div class="border-t border-gray-200 dark:border-gray-700 py-2 px-4 text-xs text-gray-500 dark:text-gray-400">
+            <span class="uppercase"><%= t("app.nav.language") %></span>
+            <div class="mt-2 flex gap-3">
+              <%= link_to t("app.nav.locale.en"), url_for(locale: :en),
+                  class: "#{I18n.locale.to_s == 'en' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
+              <%= link_to t("app.nav.locale.pt_br"), url_for(locale: :'pt-BR'),
+                  class: "#{I18n.locale.to_s == 'pt-BR' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
+            </div>
           </div>
           <div class="border-t border-gray-200 dark:border-gray-700 pb-3 pt-4">
             <div class="flex items-center px-4">

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -37,14 +37,6 @@
         </svg>
       </button>
     </div>
-    <div class="fixed top-4 right-4 z-50 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
-      <span class="uppercase"><%= t("app.nav.language") %></span>
-      <%= link_to t("app.nav.locale.en"), url_for(locale: :en),
-          class: "#{I18n.locale.to_s == 'en' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
-      <%= link_to t("app.nav.locale.pt_br"), url_for(locale: :'pt-BR'),
-          class: "#{I18n.locale.to_s == 'pt-BR' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
-    </div>
-
     <main class="min-h-screen">
       <%= yield %>
     </main>

--- a/app/views/layouts/devise.html.erb
+++ b/app/views/layouts/devise.html.erb
@@ -1,7 +1,7 @@
 <!DOCTYPE html>
-<html>
+<html lang="<%= I18n.locale %>">
   <head>
-    <title>Finance App - <%= yield(:title) || "Sign In" %></title>
+    <title><%= t("app.name") %> - <%= yield(:title) || t("devise.views.sessions.new.title") %></title>
     <meta name="viewport" content="width=device-width,initial-scale=1">
     <%= csrf_meta_tags %>
     <%= csp_meta_tag %>
@@ -36,6 +36,13 @@
           <!-- Icon will be inserted by Stimulus controller -->
         </svg>
       </button>
+    </div>
+    <div class="fixed top-4 right-4 z-50 flex items-center gap-2 text-xs text-gray-500 dark:text-gray-400">
+      <span class="uppercase"><%= t("app.nav.language") %></span>
+      <%= link_to t("app.nav.locale.en"), url_for(locale: :en),
+          class: "#{I18n.locale.to_s == 'en' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
+      <%= link_to t("app.nav.locale.pt_br"), url_for(locale: :'pt-BR'),
+          class: "#{I18n.locale.to_s == 'pt-BR' ? 'text-gray-900 dark:text-white font-semibold' : 'hover:text-gray-700 dark:hover:text-gray-200'}" %>
     </div>
 
     <main class="min-h-screen">

--- a/app/views/reports_mailer/monthly_summary.text.erb
+++ b/app/views/reports_mailer/monthly_summary.text.erb
@@ -1,9 +1,9 @@
-Hi <%= @user.email %>,
+<%= t("mailers.reports.monthly_summary.greeting", email: @user.email) %>
 
-Here is your monthly financial summary for <%= @summary[:month] %>:
+<%= t("mailers.reports.monthly_summary.summary", month: @summary[:month]) %>
 
-- Income: <%= number_to_currency(@summary[:income]) %>
-- Expenses: <%= number_to_currency(@summary[:expenses]) %>
-- Balance: <%= number_to_currency(@summary[:balance]) %>
+- <%= t("mailers.reports.monthly_summary.income", amount: number_to_currency(@summary[:income])) %>
+- <%= t("mailers.reports.monthly_summary.expenses", amount: number_to_currency(@summary[:expenses])) %>
+- <%= t("mailers.reports.monthly_summary.balance", amount: number_to_currency(@summary[:balance])) %>
 
-Generated automatically by Finance App.
+<%= t("mailers.reports.monthly_summary.footer") %>

--- a/app/views/shared/_balance_summary.html.erb
+++ b/app/views/shared/_balance_summary.html.erb
@@ -1,6 +1,6 @@
 <div class="grid grid-cols-1 gap-4 sm:grid-cols-3" data-controller="balance">
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6 transition-all duration-300 hover:shadow-md">
-    <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Total Income</dt>
+    <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("shared.balance_summary.total_income") %></dt>
     <dd class="mt-1 text-2xl font-semibold tracking-tight text-green-600 dark:text-green-400 balance-amount transition-colors duration-300" 
         data-balance-target="amount">
       <%= number_to_currency(user.total_income) %>
@@ -8,7 +8,7 @@
   </div>
   
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6 transition-all duration-300 hover:shadow-md">
-    <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Total Expenses</dt>
+    <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("shared.balance_summary.total_expenses") %></dt>
     <dd class="mt-1 text-2xl font-semibold tracking-tight text-red-600 dark:text-red-400 balance-amount transition-colors duration-300" 
         data-balance-target="amount">
       <%= number_to_currency(user.total_expenses) %>
@@ -16,7 +16,7 @@
   </div>
   
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6 transition-all duration-300 hover:shadow-md">
-    <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400">Balance</dt>
+    <dt class="truncate text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("shared.balance_summary.balance") %></dt>
     <dd class="mt-1 text-2xl font-semibold tracking-tight balance-amount <%= user.balance >= 0 ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %> transition-colors duration-300" 
         data-balance-target="amount">
       <%= number_to_currency(user.balance) %>

--- a/app/views/shared/_loading.html.erb
+++ b/app/views/shared/_loading.html.erb
@@ -1,4 +1,4 @@
 <div class="flex items-center justify-center py-8">
   <div class="animate-spin rounded-full h-8 w-8 border-b-2 border-indigo-600 dark:border-indigo-400"></div>
-  <span class="ml-3 text-sm text-gray-600 dark:text-gray-400">Loading...</span>
+  <span class="ml-3 text-sm text-gray-600 dark:text-gray-400"><%= t("common.loading") %></span>
 </div>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -9,7 +9,7 @@
         </div>
         <div class="ml-3">
           <h3 class="text-sm font-medium text-red-800 dark:text-red-200">
-            There were <%= pluralize(transaction.errors.count, "error") %> with your submission
+            <%= t("transactions.form.errors", count: transaction.errors.count) %>
           </h3>
           <div class="mt-2 text-sm text-red-700 dark:text-red-300">
             <ul class="list-disc pl-5 space-y-1">
@@ -25,7 +25,7 @@
 
   <div class="space-y-6">
     <fieldset>
-      <legend class="text-sm font-medium text-gray-700 dark:text-gray-300">Transaction Type</legend>
+      <legend class="text-sm font-medium text-gray-700 dark:text-gray-300"><%= t("transactions.form.transaction_type") %></legend>
       <div class="mt-2 grid grid-cols-2 gap-3">
         <label class="relative flex cursor-pointer rounded-lg border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 p-4 shadow-sm focus:outline-none">
           <%= form.radio_button :transaction_type, "income", 
@@ -33,8 +33,8 @@
               data: { action: "change->transaction-form#updateAmountColor" } %>
           <span class="flex flex-1">
             <span class="flex flex-col">
-              <span class="block text-sm font-medium text-gray-900 dark:text-white">Income</span>
-              <span class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400">Money coming in</span>
+              <span class="block text-sm font-medium text-gray-900 dark:text-white"><%= t("transactions.form.income") %></span>
+              <span class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400"><%= t("transactions.form.income_hint") %></span>
             </span>
           </span>
           <svg class="h-5 w-5 text-green-600 dark:text-green-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -49,8 +49,8 @@
               data: { action: "change->transaction-form#updateAmountColor" } %>
           <span class="flex flex-1">
             <span class="flex flex-col">
-              <span class="block text-sm font-medium text-gray-900 dark:text-white">Expense</span>
-              <span class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400">Money going out</span>
+              <span class="block text-sm font-medium text-gray-900 dark:text-white"><%= t("transactions.form.expense") %></span>
+              <span class="mt-1 flex items-center text-sm text-gray-500 dark:text-gray-400"><%= t("transactions.form.expense_hint") %></span>
             </span>
           </span>
           <svg class="h-5 w-5 text-red-600 dark:text-red-400" xmlns="http://www.w3.org/2000/svg" viewBox="0 0 20 20" fill="currentColor" aria-hidden="true">
@@ -87,11 +87,11 @@
     </div>
     
     <div>
-      <%= form.label :category_id, "Category", class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+      <%= form.label :category_id, t("transactions.form.category"), class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="mt-1">
         <%= form.select :category_id,
             options_for_select(@categories.map { |c| [c.name, c.id, { "data-color" => c.color }] }, transaction.category_id),
-            { prompt: "Select a category" },
+            { prompt: t("transactions.form.select_category") },
             { required: true, class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm transition-colors duration-200" } %>
       </div>
     </div>
@@ -102,7 +102,7 @@
         <%= form.text_area :description, 
             rows: 3,
             class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white shadow-sm focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm",
-            placeholder: "Optional notes about this transaction" %>
+            placeholder: t("transactions.form.description_placeholder") %>
       </div>
     </div>
   </div>
@@ -111,7 +111,7 @@
     <button type="button" 
             class="rounded-md border border-gray-300 dark:border-gray-600 bg-white dark:bg-gray-700 py-2 px-4 text-sm font-medium text-gray-700 dark:text-gray-300 shadow-sm hover:bg-gray-50 dark:hover:bg-gray-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
             data-action="click->modal#close">
-      Cancel
+      <%= t("transactions.form.cancel") %>
     </button>
     <%= form.submit class: "inline-flex justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 py-2 px-4 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 transition-all duration-200", 
         data: { transaction_form_target: "submitButton" } %>

--- a/app/views/transactions/_form.html.erb
+++ b/app/views/transactions/_form.html.erb
@@ -65,14 +65,14 @@
       <%= form.label :amount, class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
       <div class="relative mt-1 rounded-md shadow-sm">
         <div class="pointer-events-none absolute inset-y-0 left-0 flex items-center pl-3">
-          <span class="text-gray-500 dark:text-gray-400 sm:text-sm">$</span>
+          <span class="text-gray-500 dark:text-gray-400 sm:text-sm"><%= currency_unit(strip: true) %></span>
         </div>
         <%= form.number_field :amount, 
             step: 0.01,
             min: 0.01,
             required: true,
             class: "block w-full rounded-md border-gray-300 dark:border-gray-600 dark:bg-gray-700 dark:text-white pl-7 pr-12 focus:border-indigo-500 focus:ring-indigo-500 sm:text-sm transition-colors duration-200",
-            placeholder: "0.00",
+            placeholder: t("transactions.form.amount_placeholder"),
             data: { transaction_form_target: "amountInput" } %>
       </div>
     </div>

--- a/app/views/transactions/_transaction.html.erb
+++ b/app/views/transactions/_transaction.html.erb
@@ -6,7 +6,7 @@
     
     <div class="min-w-0 flex-1">
       <p class="text-sm font-medium text-gray-900 dark:text-white truncate">
-        <%= transaction.description.presence || "No description" %>
+        <%= transaction.description.presence || t("transactions.item.no_description") %>
       </p>
       <p class="text-sm text-gray-500 dark:text-gray-400">
         <%= transaction.category.name %> • 
@@ -37,7 +37,7 @@
       <%= button_to transaction_path(transaction), 
           method: :delete,
           class: "p-1 text-gray-400 hover:text-red-600 dark:hover:text-red-400 transition-colors",
-          confirm: "Are you sure you want to delete this transaction?",
+          confirm: t("transactions.item.delete_confirm"),
           form: { data: { turbo_method: :delete } } do %>
         <svg class="w-4 h-4" fill="none" stroke="currentColor" viewBox="0 0 24 24">
           <path stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M19 7l-.867 12.142A2 2 0 0116.138 21H7.862a2 2 0 01-1.995-1.858L5 7m5 4v6m4-6v6m1-10V4a1 1 0 00-1-1h-4a1 1 0 00-1 1v3M4 7h16"></path>

--- a/app/views/transactions/_transaction_mobile_card.html.erb
+++ b/app/views/transactions/_transaction_mobile_card.html.erb
@@ -8,7 +8,7 @@
         </p>
       </div>
       <div class="mt-1 flex items-center justify-between">
-        <p class="text-xs text-gray-500 dark:text-gray-400"><%= transaction.date.strftime("%b %d, %Y") %></p>
+        <p class="text-xs text-gray-500 dark:text-gray-400"><%= localized_date(transaction.date) %></p>
         <span class="inline-flex items-center text-xs text-gray-500 dark:text-gray-400">
           <span class="h-2 w-2 rounded-full mr-1" style="background-color: <%= transaction.category_color %>"></span>
           <%= transaction.category_name %>

--- a/app/views/transactions/_transaction_mobile_card.html.erb
+++ b/app/views/transactions/_transaction_mobile_card.html.erb
@@ -17,14 +17,14 @@
     </div>
   </div>
   <div class="mt-2 flex space-x-3 text-xs">
-    <%= link_to "Edit", edit_transaction_path(transaction), 
+    <%= link_to t("common.actions.edit"), edit_transaction_path(transaction),
         class: "text-indigo-600 dark:text-indigo-400",
         data: { turbo_frame: "modal" } %>
-    <%= link_to "Delete", transaction_path(transaction), 
+    <%= link_to t("common.actions.delete"), transaction_path(transaction),
         class: "text-red-600 dark:text-red-400",
         data: { 
           turbo_method: :delete,
-          turbo_confirm: "Are you sure?"
+          turbo_confirm: t("common.confirmations.are_you_sure")
         } %>
   </div>
 </div>

--- a/app/views/transactions/_transaction_table_row.html.erb
+++ b/app/views/transactions/_transaction_table_row.html.erb
@@ -15,14 +15,14 @@
     <%= transaction.formatted_amount %>
   </td>
   <td class="relative whitespace-nowrap py-4 pl-3 pr-4 text-right text-sm font-medium sm:pr-6">
-    <%= link_to "Edit", edit_transaction_path(transaction), 
+    <%= link_to t("common.actions.edit"), edit_transaction_path(transaction),
         class: "text-indigo-600 hover:text-indigo-900 dark:text-indigo-400 dark:hover:text-indigo-300",
         data: { turbo_frame: "modal" } %>
-    <%= link_to "Delete", transaction_path(transaction), 
+    <%= link_to t("common.actions.delete"), transaction_path(transaction),
         class: "ml-4 text-red-600 hover:text-red-900 dark:text-red-400 dark:hover:text-red-300",
         data: { 
           turbo_method: :delete,
-          turbo_confirm: "Are you sure?"
+          turbo_confirm: t("common.confirmations.are_you_sure")
         } %>
   </td>
 </tr>

--- a/app/views/transactions/_transaction_table_row.html.erb
+++ b/app/views/transactions/_transaction_table_row.html.erb
@@ -1,6 +1,6 @@
 <tr id="<%= dom_id(transaction) %>">
   <td class="whitespace-nowrap py-4 pl-4 pr-3 text-sm text-gray-900 dark:text-white sm:pl-6">
-    <%= transaction.date.strftime("%b %d, %Y") %>
+    <%= localized_date(transaction.date) %>
   </td>
   <td class="px-3 py-4 text-sm text-gray-900 dark:text-white">
     <%= transaction.description %>

--- a/app/views/transactions/create.turbo_stream.erb
+++ b/app/views/transactions/create.turbo_stream.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800 dark:text-green-200">
-          Transaction was successfully created.
+          <%= t("notices.transactions.created") %>
         </p>
       </div>
       <div class="ml-auto pl-3">

--- a/app/views/transactions/destroy.turbo_stream.erb
+++ b/app/views/transactions/destroy.turbo_stream.erb
@@ -10,7 +10,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800">
-          Transaction was successfully deleted.
+          <%= t("notices.transactions.deleted") %>
         </p>
       </div>
     </div>

--- a/app/views/transactions/edit.html.erb
+++ b/app/views/transactions/edit.html.erb
@@ -19,7 +19,7 @@
           <button type="button" 
                   class="rounded-md bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   data-action="click->modal#close">
-            <span class="sr-only">Close</span>
+            <span class="sr-only"><%= t("common.actions.close") %></span>
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -29,7 +29,7 @@
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
             <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
-              Edit Transaction
+              <%= t("transactions.modal.edit_title") %>
             </h3>
             <div class="mt-6">
               <%= render "form", transaction: @transaction %>

--- a/app/views/transactions/index.html.erb
+++ b/app/views/transactions/index.html.erb
@@ -3,13 +3,13 @@
     <%= turbo_frame_tag "transactions_page" do %>
       <div class="sm:flex sm:items-center">
         <div class="sm:flex-auto">
-          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white">Transactions</h1>
+          <h1 class="text-3xl font-semibold text-gray-900 dark:text-white"><%= t("transactions.index.title") %></h1>
           <p class="mt-2 text-sm text-gray-700 dark:text-gray-300">
-            Simple transaction listing and management
+            <%= t("transactions.index.subtitle") %>
           </p>
         </div>
         <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
-          <%= link_to "New transaction", new_transaction_path, 
+          <%= link_to t("transactions.index.new_transaction"), new_transaction_path,
               class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
               data: { turbo_frame: "modal" } %>
         </div>
@@ -23,8 +23,8 @@
     <!-- Transactions Section -->
     <div class="mt-8 bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
       <div class="flex items-center justify-between mb-4">
-        <h2 class="text-lg font-semibold text-gray-900 dark:text-white">Transactions</h2>
-        <%= link_to "View Dashboard", dashboard_path, 
+        <h2 class="text-lg font-semibold text-gray-900 dark:text-white"><%= t("transactions.index.table_title") %></h2>
+        <%= link_to t("transactions.index.view_dashboard"), dashboard_path,
             class: "text-sm text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200" %>
       </div>
       
@@ -34,11 +34,11 @@
           <table class="min-w-full divide-y divide-gray-300 dark:divide-gray-700">
             <thead class="bg-gray-50 dark:bg-gray-700">
               <tr>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Transaction</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Category</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Date</th>
-                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider">Amount</th>
-                <th class="relative px-6 py-3"><span class="sr-only">Actions</span></th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"><%= t("transactions.index.columns.transaction") %></th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"><%= t("transactions.index.columns.category") %></th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"><%= t("transactions.index.columns.date") %></th>
+                <th class="px-6 py-3 text-left text-xs font-medium text-gray-500 dark:text-gray-300 uppercase tracking-wider"><%= t("transactions.index.columns.amount") %></th>
+                <th class="relative px-6 py-3"><span class="sr-only"><%= t("transactions.index.columns.actions") %></span></th>
               </tr>
             </thead>
             <tbody id="transactions-container" class="bg-white dark:bg-gray-800 divide-y divide-gray-200 dark:divide-gray-700">
@@ -49,8 +49,8 @@
               <% else %>
                 <tr>
                   <td colspan="5" class="px-6 py-8 text-center text-gray-500 dark:text-gray-400">
-                    No transactions yet
-                    <%= link_to "Add your first transaction", new_transaction_path, 
+                    <%= t("transactions.index.empty") %>
+                    <%= link_to t("transactions.index.add_first"), new_transaction_path,
                         class: "ml-2 text-blue-600 hover:text-blue-800 dark:text-blue-400 dark:hover:text-blue-200",
                         data: { turbo_frame: "modal" } %>
                   </td>
@@ -69,8 +69,8 @@
           <% end %>
         <% else %>
           <div class="text-center py-8">
-            <p class="text-gray-500 dark:text-gray-400 mb-4">No transactions yet</p>
-            <%= link_to "Add your first transaction", new_transaction_path, 
+            <p class="text-gray-500 dark:text-gray-400 mb-4"><%= t("transactions.index.empty") %></p>
+            <%= link_to t("transactions.index.add_first"), new_transaction_path,
                 class: "inline-flex items-center px-4 py-2 text-sm font-medium text-white bg-blue-600 rounded-lg hover:bg-blue-700 dark:bg-blue-500 dark:hover:bg-blue-600",
                 data: { turbo_frame: "modal" } %>
           </div>

--- a/app/views/transactions/new.html.erb
+++ b/app/views/transactions/new.html.erb
@@ -19,7 +19,7 @@
           <button type="button" 
                   class="rounded-md bg-white dark:bg-gray-800 text-gray-400 hover:text-gray-500 dark:hover:text-gray-300 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800"
                   data-action="click->modal#close">
-            <span class="sr-only">Close</span>
+            <span class="sr-only"><%= t("common.actions.close") %></span>
             <svg class="h-6 w-6" fill="none" viewBox="0 0 24 24" stroke-width="1.5" stroke="currentColor">
               <path stroke-linecap="round" stroke-linejoin="round" d="M6 18L18 6M6 6l12 12" />
             </svg>
@@ -29,7 +29,7 @@
         <div class="sm:flex sm:items-start">
           <div class="mt-3 text-center sm:mt-0 sm:text-left w-full">
             <h3 class="text-lg font-medium leading-6 text-gray-900 dark:text-white" id="modal-title">
-              New Transaction
+              <%= t("transactions.modal.new_title") %>
             </h3>
             <div class="mt-6">
               <%= render "form", transaction: @transaction %>

--- a/app/views/transactions/update.turbo_stream.erb
+++ b/app/views/transactions/update.turbo_stream.erb
@@ -13,7 +13,7 @@
       </div>
       <div class="ml-3">
         <p class="text-sm font-medium text-green-800 dark:text-green-200">
-          Transaction was successfully updated.
+          <%= t("notices.transactions.updated") %>
         </p>
       </div>
       <div class="ml-auto pl-3">

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,8 +23,8 @@ module FinanceApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
-    config.i18n.default_locale = :"pt-BR"
-    config.i18n.available_locales = [ :"pt-BR", :en ]
+    config.i18n.default_locale = :en
+    config.i18n.available_locales = [ :en, :"pt-BR" ]
     config.i18n.fallbacks = [ :en ]
   end
 end

--- a/config/application.rb
+++ b/config/application.rb
@@ -23,5 +23,8 @@ module FinanceApp
     #
     # config.time_zone = "Central Time (US & Canada)"
     # config.eager_load_paths << Rails.root.join("extras")
+    config.i18n.default_locale = :"pt-BR"
+    config.i18n.available_locales = [ :"pt-BR", :en ]
+    config.i18n.fallbacks = [ :en ]
   end
 end

--- a/config/environments/development.rb
+++ b/config/environments/development.rb
@@ -56,7 +56,7 @@ Rails.application.configure do
   config.active_job.verbose_enqueue_logs = true
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -46,7 +46,7 @@ Rails.application.configure do
   config.active_support.deprecation = :stderr
 
   # Raises error for missing translations.
-  # config.i18n.raise_on_missing_translations = true
+  config.i18n.raise_on_missing_translations = true
 
   # Annotate rendered view with file names.
   # config.action_view.annotate_rendered_view_with_filenames = true

--- a/config/locales/devise.pt-BR.yml
+++ b/config/locales/devise.pt-BR.yml
@@ -1,0 +1,63 @@
+"pt-BR":
+  devise:
+    confirmations:
+      confirmed: "Seu endereco de e-mail foi confirmado com sucesso."
+      send_instructions: "Voce recebera um e-mail com instrucoes para confirmar seu endereco de e-mail em alguns minutos."
+      send_paranoid_instructions: "Se seu endereco de e-mail existir em nossa base, voce recebera um e-mail com instrucoes para confirmar seu endereco de e-mail em alguns minutos."
+    failure:
+      already_authenticated: "Voce ja esta autenticado."
+      inactive: "Sua conta ainda nao foi ativada."
+      invalid: "%{authentication_keys} ou senha invalida."
+      locked: "Sua conta esta bloqueada."
+      last_attempt: "Voce tem mais uma tentativa antes da sua conta ser bloqueada."
+      not_found_in_database: "%{authentication_keys} ou senha invalida."
+      timeout: "Sua sessao expirou. Entre novamente para continuar."
+      unauthenticated: "Voce precisa entrar ou se cadastrar antes de continuar."
+      unconfirmed: "Voce precisa confirmar seu endereco de e-mail antes de continuar."
+    mailer:
+      confirmation_instructions:
+        subject: "Instrucoes de confirmacao"
+      reset_password_instructions:
+        subject: "Instrucoes para redefinicao de senha"
+      unlock_instructions:
+        subject: "Instrucoes de desbloqueio"
+      email_changed:
+        subject: "E-mail alterado"
+      password_change:
+        subject: "Senha alterada"
+    omniauth_callbacks:
+      failure: "Nao foi possivel autenticar com %{kind} porque \"%{reason}\"."
+      success: "Autenticado com sucesso com a conta %{kind}."
+    passwords:
+      no_token: "Voce nao pode acessar esta pagina sem vir de um e-mail de redefinicao de senha. Se voce veio de um e-mail, confirme se usou a URL completa."
+      send_instructions: "Voce recebera um e-mail com instrucoes para redefinir sua senha em alguns minutos."
+      send_paranoid_instructions: "Se seu endereco de e-mail existir em nossa base, voce recebera um link de recuperacao em alguns minutos."
+      updated: "Sua senha foi alterada com sucesso. Voce esta autenticado agora."
+      updated_not_active: "Sua senha foi alterada com sucesso."
+    registrations:
+      destroyed: "Conta cancelada com sucesso. Esperamos ver voce novamente em breve."
+      signed_up: "Bem-vindo! Seu cadastro foi realizado com sucesso."
+      signed_up_but_inactive: "Cadastro realizado com sucesso. No entanto, nao foi possivel entrar porque sua conta ainda nao foi ativada."
+      signed_up_but_locked: "Cadastro realizado com sucesso. No entanto, nao foi possivel entrar porque sua conta esta bloqueada."
+      signed_up_but_unconfirmed: "Enviamos uma mensagem com link de confirmacao para seu e-mail. Siga o link para ativar sua conta."
+      update_needs_confirmation: "Sua conta foi atualizada com sucesso, mas precisamos verificar seu novo e-mail. Verifique sua caixa de entrada e siga o link de confirmacao."
+      updated: "Sua conta foi atualizada com sucesso."
+      updated_but_not_signed_in: "Sua conta foi atualizada com sucesso, mas como a senha foi alterada voce precisa entrar novamente."
+    sessions:
+      signed_in: "Login realizado com sucesso."
+      signed_out: "Logout realizado com sucesso."
+      already_signed_out: "Logout realizado com sucesso."
+    unlocks:
+      send_instructions: "Voce recebera um e-mail com instrucoes para desbloquear sua conta em alguns minutos."
+      send_paranoid_instructions: "Se sua conta existir, voce recebera um e-mail com instrucoes para desbloqueio em alguns minutos."
+      unlocked: "Sua conta foi desbloqueada com sucesso. Entre para continuar."
+  errors:
+    messages:
+      already_confirmed: "ja foi confirmado, tente entrar"
+      confirmation_period_expired: "precisa ser confirmado em ate %{period}, solicite um novo"
+      expired: "expirou, solicite um novo"
+      not_found: "nao encontrado"
+      not_locked: "nao estava bloqueado"
+      not_saved:
+        one: "1 erro impediu que este %{resource} fosse salvo:"
+        other: "%{count} erros impediram que este %{resource} fosse salvo:"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,10 +37,6 @@ en:
       goals: "Goals"
       categories: "Categories"
       sign_out: "Sign out"
-      language: "Language"
-      locale:
-        en: "EN"
-        pt_br: "PT-BR"
   home:
     title: "Welcome to Finance App"
     logged_in_as: "Logged in as"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -37,6 +37,10 @@ en:
       goals: "Goals"
       categories: "Categories"
       sign_out: "Sign out"
+      language: "Language"
+      locale:
+        en: "EN"
+        pt_br: "PT-BR"
   home:
     title: "Welcome to Finance App"
     logged_in_as: "Logged in as"
@@ -70,6 +74,7 @@ en:
       registrations:
         new:
           title: "Create your account"
+          email_placeholder: "name@example.com"
           password_placeholder: "Create a password"
           password_confirmation_placeholder: "Confirm your password"
           minimum_password_length: "(%{count} characters minimum)"
@@ -163,6 +168,7 @@ en:
       category: "Category"
       select_category: "Select a category"
       description_placeholder: "Optional notes about this transaction"
+      amount_placeholder: "0.00"
       cancel: "Cancel"
     modal:
       new_title: "New Transaction"
@@ -185,6 +191,7 @@ en:
         one: "There was 1 error with your submission"
         other: "There were %{count} errors with your submission"
       name_placeholder: "e.g. Food, Transport, Salary"
+      color_placeholder: "#FF5733"
       color_hint: "Choose a color to identify this category"
       cancel: "Cancel"
     modal:
@@ -218,6 +225,8 @@ en:
       category_optional: "Category (optional)"
       category_prompt: "Select category (optional)"
       description_placeholder: "Describe your goal and why it's important to you..."
+      target_amount_placeholder: "10000.00"
+      current_amount_placeholder: "0.00"
       update_goal: "Update Goal"
       create_goal: "Create Goal"
     modal:
@@ -270,6 +279,8 @@ en:
       new_current_amount: "New Current Amount"
       remaining: "Remaining"
       submit: "Update Progress"
+      amount_placeholder: "0.00"
+      quick_add: "+%{unit}%{amount}"
   common:
     actions:
       title: "Actions"
@@ -278,8 +289,10 @@ en:
       edit: "Edit"
       delete: "Delete"
       view: "View"
+      dismiss: "Dismiss"
     confirmations:
       are_you_sure: "Are you sure?"
+    loading: "Loading..."
   helpers:
     submit:
       category:
@@ -297,6 +310,11 @@ en:
       transaction: "Transaction"
       goal: "Goal"
     attributes:
+      user:
+        email: "Email"
+        password: "Password"
+        password_confirmation: "Password confirmation"
+        current_password: "Current password"
       category:
         name: "Name"
         color: "Color"
@@ -336,11 +354,41 @@ en:
       deleted: "Goal deleted successfully"
       progress_updated: "Goal progress updated successfully"
       progress_update_failed: "Unable to update goal progress"
+  jobs:
+    monitoring:
+      title: "Jobs Monitoring"
+      subtitle: "Current background processing snapshot from Solid Queue."
+      status:
+        pending: "Pending"
+        running: "Running"
+        failed: "Failed"
+        finished: "Finished"
+  mailers:
+    goal_notifications:
+      due_soon:
+        greeting: "Hi %{email},"
+        summary: "Your goal \"%{title}\" is due in %{days} day(s)."
+        current_progress: "Current progress: %{progress}"
+        target_amount: "Target amount: %{amount}"
+        current_amount: "Current amount: %{amount}"
+        encouragement: "Keep going!"
+    reports:
+      monthly_summary:
+        greeting: "Hi %{email},"
+        summary: "Here is your monthly financial summary for %{month}:"
+        income: "Income: %{amount}"
+        expenses: "Expenses: %{amount}"
+        balance: "Balance: %{amount}"
+        footer: "Generated automatically by Finance App."
   number:
     currency:
       format:
-        unit: "R$ "
-        separator: ","
-        delimiter: "."
+        unit: "$"
+        separator: "."
+        delimiter: ","
         format: "%u%n"
         negative_format: "-%u%n"
+  date:
+    formats:
+      short: "%b %d, %Y"
+      long: "%B %d, %Y"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -263,6 +263,13 @@ en:
         one: "Overdue by 1 day"
         other: "Overdue by %{count} days"
       created: "Created"
+    progress_modal:
+      title: "Update Progress"
+      current: "Current"
+      target: "Target"
+      new_current_amount: "New Current Amount"
+      remaining: "Remaining"
+      submit: "Update Progress"
   common:
     actions:
       title: "Actions"
@@ -273,6 +280,42 @@ en:
       view: "View"
     confirmations:
       are_you_sure: "Are you sure?"
+  helpers:
+    submit:
+      category:
+        create: "Create Category"
+        update: "Update Category"
+      transaction:
+        create: "Create Transaction"
+        update: "Update Transaction"
+      goal:
+        create: "Create Goal"
+        update: "Update Goal"
+  activerecord:
+    models:
+      category: "Category"
+      transaction: "Transaction"
+      goal: "Goal"
+    attributes:
+      category:
+        name: "Name"
+        color: "Color"
+      transaction:
+        amount: "Amount"
+        date: "Date"
+        description: "Description"
+        category: "Category"
+        category_id: "Category"
+        transaction_type: "Transaction Type"
+      goal:
+        title: "Title"
+        goal_type: "Goal Type"
+        target_amount: "Target Amount"
+        current_amount: "Current Amount"
+        target_date: "Target Date"
+        status: "Status"
+        description: "Description"
+        category_id: "Category"
   shared:
     balance_summary:
       total_income: "Total Income"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -132,6 +132,10 @@ en:
         this_month: "This month"
         custom_range: "Custom range"
         clear: "Clear filters"
+    charts:
+      income_vs_expenses: "Income vs Expenses"
+      expenses_by_category: "Expenses by Category"
+      monthly_evolution: "Monthly Evolution"
   transactions:
     index:
       title: "Transactions"
@@ -160,6 +164,115 @@ en:
       select_category: "Select a category"
       description_placeholder: "Optional notes about this transaction"
       cancel: "Cancel"
+    modal:
+      new_title: "New Transaction"
+      edit_title: "Edit Transaction"
+    item:
+      no_description: "No description"
+      delete_confirm: "Are you sure you want to delete this transaction?"
+  categories:
+    index:
+      title: "Categories"
+      subtitle: "Manage your transaction categories"
+      new_category: "New category"
+      columns:
+        name: "Name"
+        color: "Color"
+        transactions: "Transactions"
+        actions: "Actions"
+    form:
+      errors:
+        one: "There was 1 error with your submission"
+        other: "There were %{count} errors with your submission"
+      name_placeholder: "e.g. Food, Transport, Salary"
+      color_hint: "Choose a color to identify this category"
+      cancel: "Cancel"
+    modal:
+      new_title: "New Category"
+      edit_title: "Edit Category"
+  goals:
+    index:
+      title: "Goals"
+      subtitle: "Track and manage your financial objectives"
+      new_goal: "New goal"
+      filters:
+        search_placeholder: "Search goals..."
+        all_status: "All Status"
+        all_types: "All Types"
+    types:
+      savings: "Savings"
+      expense_reduction: "Expense Reduction"
+      income_increase: "Income Increase"
+      debt_payoff: "Debt Payoff"
+    status:
+      active: "Active"
+      paused: "Paused"
+      completed: "Completed"
+      cancelled: "Cancelled"
+    form:
+      errors:
+        one: "There was 1 error with your submission"
+        other: "There were %{count} errors with your submission"
+      title_placeholder: "e.g., Emergency Fund"
+      goal_type_prompt: "Select goal type"
+      category_optional: "Category (optional)"
+      category_prompt: "Select category (optional)"
+      description_placeholder: "Describe your goal and why it's important to you..."
+      update_goal: "Update Goal"
+      create_goal: "Create Goal"
+    modal:
+      new_title: "New Goal"
+      edit_title: "Edit Goal"
+    list:
+      empty_title: "No goals found"
+      empty_subtitle: "Try adjusting your search or filters to find what you're looking for."
+    card:
+      progress: "Progress"
+      target_date: "Target Date:"
+      days_remaining: "Days Remaining:"
+      remaining: "Remaining:"
+      overdue: "Overdue"
+      days_count:
+        one: "1 day"
+        other: "%{count} days"
+      update_progress: "Update Progress"
+    summary:
+      overview: "Goals Overview"
+      view_all: "View All Goals"
+      total: "Total Goals"
+      overdue: "Overdue"
+      recent: "Recent Goals"
+      due: "Due"
+      due_soon: "Due Soon"
+      add_new: "Add New Goal"
+      empty_title: "No Goals Yet"
+      empty_subtitle: "Start tracking your financial objectives by creating your first goal."
+      create_first: "Create Your First Goal"
+    show:
+      edit_goal: "Edit Goal"
+      update_progress: "Update Progress"
+      delete_goal: "Delete Goal"
+      delete_confirm: "Are you sure you want to delete this goal? This action cannot be undone."
+      description: "Description"
+      progress_details: "Progress Details"
+      overall_progress: "Overall Progress"
+      current_amount: "Current Amount"
+      target_amount: "Target Amount"
+      goal_information: "Goal Information"
+      overdue_by_days:
+        one: "Overdue by 1 day"
+        other: "Overdue by %{count} days"
+      created: "Created"
+  common:
+    actions:
+      title: "Actions"
+      close: "Close"
+      cancel: "Cancel"
+      edit: "Edit"
+      delete: "Delete"
+      view: "View"
+    confirmations:
+      are_you_sure: "Are you sure?"
   shared:
     balance_summary:
       total_income: "Total Income"

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -29,6 +29,157 @@
 
 en:
   hello: "Hello world"
+  app:
+    name: "Finance App"
+    nav:
+      dashboard: "Dashboard"
+      transactions: "Transactions"
+      goals: "Goals"
+      categories: "Categories"
+      sign_out: "Sign out"
+  home:
+    title: "Welcome to Finance App"
+    logged_in_as: "Logged in as"
+    dashboard_title: "Dashboard"
+    dashboard_placeholder: "Your financial dashboard will appear here."
+  devise:
+    views:
+      shared:
+        links:
+          sign_in: "Log in"
+          sign_up: "Sign up"
+          forgot_password: "Forgot your password?"
+          confirmation_instructions: "Didn't receive confirmation instructions?"
+          unlock_instructions: "Didn't receive unlock instructions?"
+          sign_in_with_provider: "Sign in with %{provider}"
+      confirmations:
+        new:
+          title: "Resend confirmation instructions"
+          submit: "Resend confirmation instructions"
+      unlocks:
+        new:
+          title: "Resend unlock instructions"
+          submit: "Resend unlock instructions"
+      sessions:
+        new:
+          title: "Sign in to Finance App"
+          email_placeholder: "name@example.com"
+          password_placeholder: "Enter your password"
+          remember_me: "Remember me"
+          submit: "Sign in"
+      registrations:
+        new:
+          title: "Create your account"
+          password_placeholder: "Create a password"
+          password_confirmation_placeholder: "Confirm your password"
+          minimum_password_length: "(%{count} characters minimum)"
+          submit: "Sign up"
+        edit:
+          title: "Edit %{resource}"
+          waiting_confirmation: "Currently waiting confirmation for: %{email}"
+          leave_blank: "(leave blank if you don't want to change it)"
+          current_password_help: "(we need your current password to confirm your changes)"
+          update: "Update"
+          cancel_title: "Cancel my account"
+          unhappy: "Unhappy?"
+          cancel_account: "Cancel my account"
+          back: "Back"
+          confirm_cancel: "Are you sure?"
+      passwords:
+        new:
+          title: "Forgot your password?"
+          email_placeholder: "Enter your email address"
+          submit: "Send me reset password instructions"
+        edit:
+          title: "Change your password"
+          new_password: "New password"
+          confirm_new_password: "Confirm new password"
+          minimum_password_length: "(%{count} characters minimum)"
+          submit: "Change my password"
+      mailer:
+        greeting: "Hello %{email}!"
+        welcome: "Welcome %{email}!"
+        confirmation_instructions: "You can confirm your account email through the link below:"
+        confirm_account: "Confirm my account"
+        email_changed_pending: "We're contacting you to notify you that your email is being changed to %{email}."
+        email_changed: "We're contacting you to notify you that your email has been changed to %{email}."
+        password_changed: "We're contacting you to notify you that your password has been changed."
+        reset_password_instructions: "Someone has requested a link to change your password. You can do this through the link below."
+        change_password: "Change my password"
+        ignore_email: "If you didn't request this, please ignore this email."
+        password_wont_change: "Your password won't change until you access the link above and create a new one."
+        account_locked: "Your account has been locked due to an excessive number of unsuccessful sign in attempts."
+        unlock_instructions: "Click the link below to unlock your account:"
+        unlock_account: "Unlock my account"
+  dashboard:
+    index:
+      title: "Dashboard"
+      subtitle: "Financial overview and transaction management"
+      export_csv: "Export CSV"
+      new_transaction: "New transaction"
+      filters:
+        title: "Filters"
+        search_label: "Search Description"
+        search_placeholder: "Search transactions..."
+        all: "All"
+        income: "Income"
+        expense: "Expense"
+        category: "Category"
+        all_categories: "All Categories"
+        all_time: "All time"
+        today: "Today"
+        this_week: "This week"
+        this_month: "This month"
+        custom_range: "Custom range"
+        clear: "Clear filters"
+  transactions:
+    index:
+      title: "Transactions"
+      subtitle: "Simple transaction listing and management"
+      new_transaction: "New transaction"
+      table_title: "Transactions"
+      view_dashboard: "View Dashboard"
+      empty: "No transactions yet"
+      add_first: "Add your first transaction"
+      columns:
+        transaction: "Transaction"
+        category: "Category"
+        date: "Date"
+        amount: "Amount"
+        actions: "Actions"
+    form:
+      errors:
+        one: "There was 1 error with your submission"
+        other: "There were %{count} errors with your submission"
+      transaction_type: "Transaction Type"
+      income: "Income"
+      income_hint: "Money coming in"
+      expense: "Expense"
+      expense_hint: "Money going out"
+      category: "Category"
+      select_category: "Select a category"
+      description_placeholder: "Optional notes about this transaction"
+      cancel: "Cancel"
+  shared:
+    balance_summary:
+      total_income: "Total Income"
+      total_expenses: "Total Expenses"
+      balance: "Balance"
+  notices:
+    transactions:
+      created: "Transaction was successfully created."
+      updated: "Transaction was successfully updated."
+      deleted: "Transaction was successfully deleted."
+    categories:
+      created: "Category was successfully created."
+      updated: "Category was successfully updated."
+      deleted: "Category was successfully deleted."
+    goals:
+      created: "Goal created successfully"
+      updated: "Goal updated successfully"
+      deleted: "Goal deleted successfully"
+      progress_updated: "Goal progress updated successfully"
+      progress_update_failed: "Unable to update goal progress"
   number:
     currency:
       format:

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -1,0 +1,83 @@
+"pt-BR":
+  app:
+    name: "Finance App"
+    nav:
+      dashboard: "Dashboard"
+      transactions: "Transacoes"
+      goals: "Metas"
+      categories: "Categorias"
+      sign_out: "Sair"
+  home:
+    title: "Bem-vindo ao Finance App"
+    logged_in_as: "Logado como"
+    dashboard_title: "Dashboard"
+    dashboard_placeholder: "Seu painel financeiro aparecera aqui."
+  devise:
+    views:
+      shared:
+        links:
+          sign_in: "Entrar"
+          sign_up: "Criar conta"
+          forgot_password: "Esqueceu sua senha?"
+          confirmation_instructions: "Nao recebeu instrucoes de confirmacao?"
+          unlock_instructions: "Nao recebeu instrucoes de desbloqueio?"
+          sign_in_with_provider: "Entrar com %{provider}"
+      confirmations:
+        new:
+          title: "Reenviar instrucoes de confirmacao"
+          submit: "Reenviar instrucoes de confirmacao"
+      unlocks:
+        new:
+          title: "Reenviar instrucoes de desbloqueio"
+          submit: "Reenviar instrucoes de desbloqueio"
+      sessions:
+        new:
+          title: "Entrar no Finance App"
+          email_placeholder: "nome@exemplo.com"
+          password_placeholder: "Digite sua senha"
+          remember_me: "Lembrar de mim"
+          submit: "Entrar"
+      registrations:
+        new:
+          title: "Crie sua conta"
+          password_placeholder: "Crie uma senha"
+          password_confirmation_placeholder: "Confirme sua senha"
+          minimum_password_length: "(%{count} caracteres no minimo)"
+          submit: "Criar conta"
+        edit:
+          title: "Editar %{resource}"
+          waiting_confirmation: "Aguardando confirmacao para: %{email}"
+          leave_blank: "(deixe em branco se nao quiser alterar)"
+          current_password_help: "(precisamos da sua senha atual para confirmar alteracoes)"
+          update: "Atualizar"
+          cancel_title: "Cancelar minha conta"
+          unhappy: "Nao esta satisfeito?"
+          cancel_account: "Cancelar minha conta"
+          back: "Voltar"
+          confirm_cancel: "Tem certeza?"
+      passwords:
+        new:
+          title: "Esqueceu sua senha?"
+          email_placeholder: "Digite seu e-mail"
+          submit: "Enviar instrucoes para redefinir senha"
+        edit:
+          title: "Altere sua senha"
+          new_password: "Nova senha"
+          confirm_new_password: "Confirme a nova senha"
+          minimum_password_length: "(%{count} caracteres no minimo)"
+          submit: "Alterar minha senha"
+      mailer:
+        greeting: "Ola %{email}!"
+        welcome: "Bem-vindo(a) %{email}!"
+        confirmation_instructions: "Voce pode confirmar o e-mail da sua conta pelo link abaixo:"
+        confirm_account: "Confirmar minha conta"
+        email_changed_pending: "Estamos entrando em contato para avisar que seu e-mail sera alterado para %{email}."
+        email_changed: "Estamos entrando em contato para avisar que seu e-mail foi alterado para %{email}."
+        password_changed: "Estamos entrando em contato para avisar que sua senha foi alterada."
+        reset_password_instructions: "Alguem solicitou um link para alterar sua senha. Voce pode fazer isso pelo link abaixo."
+        change_password: "Alterar minha senha"
+        ignore_email: "Se voce nao solicitou isso, ignore este e-mail."
+        password_wont_change: "Sua senha nao mudara ate voce acessar o link acima e criar uma nova."
+        account_locked: "Sua conta foi bloqueada devido a um numero excessivo de tentativas sem sucesso de login."
+        unlock_instructions: "Clique no link abaixo para desbloquear sua conta:"
+        unlock_account: "Desbloquear minha conta"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -130,6 +130,11 @@
       select_category: "Selecione uma categoria"
       description_placeholder: "Observacoes opcionais sobre esta transacao"
       cancel: "Cancelar"
+  shared:
+    balance_summary:
+      total_income: "Total de receitas"
+      total_expenses: "Total de despesas"
+      balance: "Saldo"
   notices:
     transactions:
       created: "Transacao criada com sucesso."

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -233,6 +233,13 @@
         one: "Atrasada ha 1 dia"
         other: "Atrasada ha %{count} dias"
       created: "Criada em"
+    progress_modal:
+      title: "Atualizar progresso"
+      current: "Atual"
+      target: "Meta"
+      new_current_amount: "Novo valor atual"
+      remaining: "Restante"
+      submit: "Atualizar progresso"
   common:
     actions:
       title: "Acoes"
@@ -243,6 +250,42 @@
       view: "Ver"
     confirmations:
       are_you_sure: "Tem certeza?"
+  helpers:
+    submit:
+      category:
+        create: "Criar categoria"
+        update: "Atualizar categoria"
+      transaction:
+        create: "Criar transacao"
+        update: "Atualizar transacao"
+      goal:
+        create: "Criar meta"
+        update: "Atualizar meta"
+  activerecord:
+    models:
+      category: "Categoria"
+      transaction: "Transacao"
+      goal: "Meta"
+    attributes:
+      category:
+        name: "Nome"
+        color: "Cor"
+      transaction:
+        amount: "Valor"
+        date: "Data"
+        description: "Descricao"
+        category: "Categoria"
+        category_id: "Categoria"
+        transaction_type: "Tipo de transacao"
+      goal:
+        title: "Titulo"
+        goal_type: "Tipo da meta"
+        target_amount: "Valor alvo"
+        current_amount: "Valor atual"
+        target_date: "Data alvo"
+        status: "Status"
+        description: "Descricao"
+        category_id: "Categoria"
   shared:
     balance_summary:
       total_income: "Total de receitas"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -102,6 +102,10 @@
         this_month: "Este mes"
         custom_range: "Periodo personalizado"
         clear: "Limpar filtros"
+    charts:
+      income_vs_expenses: "Receitas vs despesas"
+      expenses_by_category: "Despesas por categoria"
+      monthly_evolution: "Evolucao mensal"
   transactions:
     index:
       title: "Transacoes"
@@ -130,6 +134,115 @@
       select_category: "Selecione uma categoria"
       description_placeholder: "Observacoes opcionais sobre esta transacao"
       cancel: "Cancelar"
+    modal:
+      new_title: "Nova transacao"
+      edit_title: "Editar transacao"
+    item:
+      no_description: "Sem descricao"
+      delete_confirm: "Tem certeza que deseja excluir esta transacao?"
+  categories:
+    index:
+      title: "Categorias"
+      subtitle: "Gerencie as categorias das suas transacoes"
+      new_category: "Nova categoria"
+      columns:
+        name: "Nome"
+        color: "Cor"
+        transactions: "Transacoes"
+        actions: "Acoes"
+    form:
+      errors:
+        one: "Houve 1 erro no envio"
+        other: "Houve %{count} erros no envio"
+      name_placeholder: "ex.: Alimentacao, Transporte, Salario"
+      color_hint: "Escolha uma cor para identificar esta categoria"
+      cancel: "Cancelar"
+    modal:
+      new_title: "Nova categoria"
+      edit_title: "Editar categoria"
+  goals:
+    index:
+      title: "Metas"
+      subtitle: "Acompanhe e gerencie seus objetivos financeiros"
+      new_goal: "Nova meta"
+      filters:
+        search_placeholder: "Buscar metas..."
+        all_status: "Todos os status"
+        all_types: "Todos os tipos"
+    types:
+      savings: "Poupanca"
+      expense_reduction: "Reducao de despesas"
+      income_increase: "Aumento de receita"
+      debt_payoff: "Quitacao de dividas"
+    status:
+      active: "Ativa"
+      paused: "Pausada"
+      completed: "Concluida"
+      cancelled: "Cancelada"
+    form:
+      errors:
+        one: "Houve 1 erro no envio"
+        other: "Houve %{count} erros no envio"
+      title_placeholder: "ex.: Reserva de emergencia"
+      goal_type_prompt: "Selecione o tipo de meta"
+      category_optional: "Categoria (opcional)"
+      category_prompt: "Selecione uma categoria (opcional)"
+      description_placeholder: "Descreva sua meta e por que ela e importante para voce..."
+      update_goal: "Atualizar meta"
+      create_goal: "Criar meta"
+    modal:
+      new_title: "Nova meta"
+      edit_title: "Editar meta"
+    list:
+      empty_title: "Nenhuma meta encontrada"
+      empty_subtitle: "Ajuste sua busca ou filtros para encontrar o que procura."
+    card:
+      progress: "Progresso"
+      target_date: "Data alvo:"
+      days_remaining: "Dias restantes:"
+      remaining: "Restante:"
+      overdue: "Atrasada"
+      days_count:
+        one: "1 dia"
+        other: "%{count} dias"
+      update_progress: "Atualizar progresso"
+    summary:
+      overview: "Visao geral das metas"
+      view_all: "Ver todas"
+      total: "Total de metas"
+      overdue: "Atrasadas"
+      recent: "Metas recentes"
+      due: "Vencimento"
+      due_soon: "Vence em breve"
+      add_new: "Adicionar nova meta"
+      empty_title: "Nenhuma meta ainda"
+      empty_subtitle: "Comece a acompanhar seus objetivos financeiros criando sua primeira meta."
+      create_first: "Criar primeira meta"
+    show:
+      edit_goal: "Editar meta"
+      update_progress: "Atualizar progresso"
+      delete_goal: "Excluir meta"
+      delete_confirm: "Tem certeza que deseja excluir esta meta? Esta acao nao pode ser desfeita."
+      description: "Descricao"
+      progress_details: "Detalhes do progresso"
+      overall_progress: "Progresso geral"
+      current_amount: "Valor atual"
+      target_amount: "Valor alvo"
+      goal_information: "Informacoes da meta"
+      overdue_by_days:
+        one: "Atrasada ha 1 dia"
+        other: "Atrasada ha %{count} dias"
+      created: "Criada em"
+  common:
+    actions:
+      title: "Acoes"
+      close: "Fechar"
+      cancel: "Cancelar"
+      edit: "Editar"
+      delete: "Excluir"
+      view: "Ver"
+    confirmations:
+      are_you_sure: "Tem certeza?"
   shared:
     balance_summary:
       total_income: "Total de receitas"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -81,3 +81,67 @@
         account_locked: "Sua conta foi bloqueada devido a um numero excessivo de tentativas sem sucesso de login."
         unlock_instructions: "Clique no link abaixo para desbloquear sua conta:"
         unlock_account: "Desbloquear minha conta"
+  dashboard:
+    index:
+      title: "Dashboard"
+      subtitle: "Visao financeira e gestao de transacoes"
+      export_csv: "Exportar CSV"
+      new_transaction: "Nova transacao"
+      filters:
+        title: "Filtros"
+        search_label: "Buscar descricao"
+        search_placeholder: "Buscar transacoes..."
+        all: "Todas"
+        income: "Receita"
+        expense: "Despesa"
+        category: "Categoria"
+        all_categories: "Todas as categorias"
+        all_time: "Todo periodo"
+        today: "Hoje"
+        this_week: "Esta semana"
+        this_month: "Este mes"
+        custom_range: "Periodo personalizado"
+        clear: "Limpar filtros"
+  transactions:
+    index:
+      title: "Transacoes"
+      subtitle: "Listagem e gestao de transacoes"
+      new_transaction: "Nova transacao"
+      table_title: "Transacoes"
+      view_dashboard: "Ver dashboard"
+      empty: "Nenhuma transacao ainda"
+      add_first: "Adicionar sua primeira transacao"
+      columns:
+        transaction: "Transacao"
+        category: "Categoria"
+        date: "Data"
+        amount: "Valor"
+        actions: "Acoes"
+    form:
+      errors:
+        one: "Houve 1 erro no envio"
+        other: "Houve %{count} erros no envio"
+      transaction_type: "Tipo de transacao"
+      income: "Receita"
+      income_hint: "Dinheiro entrando"
+      expense: "Despesa"
+      expense_hint: "Dinheiro saindo"
+      category: "Categoria"
+      select_category: "Selecione uma categoria"
+      description_placeholder: "Observacoes opcionais sobre esta transacao"
+      cancel: "Cancelar"
+  notices:
+    transactions:
+      created: "Transacao criada com sucesso."
+      updated: "Transacao atualizada com sucesso."
+      deleted: "Transacao removida com sucesso."
+    categories:
+      created: "Categoria criada com sucesso."
+      updated: "Categoria atualizada com sucesso."
+      deleted: "Categoria removida com sucesso."
+    goals:
+      created: "Meta criada com sucesso"
+      updated: "Meta atualizada com sucesso"
+      deleted: "Meta removida com sucesso"
+      progress_updated: "Progresso da meta atualizado com sucesso"
+      progress_update_failed: "Nao foi possivel atualizar o progresso da meta"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,10 +7,6 @@
       goals: "Metas"
       categories: "Categorias"
       sign_out: "Sair"
-      language: "Idioma"
-      locale:
-        en: "EN"
-        pt_br: "PT-BR"
   home:
     title: "Bem-vindo ao Finance App"
     logged_in_as: "Logado como"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -7,6 +7,10 @@
       goals: "Metas"
       categories: "Categorias"
       sign_out: "Sair"
+      language: "Idioma"
+      locale:
+        en: "EN"
+        pt_br: "PT-BR"
   home:
     title: "Bem-vindo ao Finance App"
     logged_in_as: "Logado como"
@@ -40,6 +44,7 @@
       registrations:
         new:
           title: "Crie sua conta"
+          email_placeholder: "nome@exemplo.com"
           password_placeholder: "Crie uma senha"
           password_confirmation_placeholder: "Confirme sua senha"
           minimum_password_length: "(%{count} caracteres no minimo)"
@@ -133,6 +138,7 @@
       category: "Categoria"
       select_category: "Selecione uma categoria"
       description_placeholder: "Observacoes opcionais sobre esta transacao"
+      amount_placeholder: "0,00"
       cancel: "Cancelar"
     modal:
       new_title: "Nova transacao"
@@ -155,6 +161,7 @@
         one: "Houve 1 erro no envio"
         other: "Houve %{count} erros no envio"
       name_placeholder: "ex.: Alimentacao, Transporte, Salario"
+      color_placeholder: "#FF5733"
       color_hint: "Escolha uma cor para identificar esta categoria"
       cancel: "Cancelar"
     modal:
@@ -188,6 +195,8 @@
       category_optional: "Categoria (opcional)"
       category_prompt: "Selecione uma categoria (opcional)"
       description_placeholder: "Descreva sua meta e por que ela e importante para voce..."
+      target_amount_placeholder: "10000,00"
+      current_amount_placeholder: "0,00"
       update_goal: "Atualizar meta"
       create_goal: "Criar meta"
     modal:
@@ -240,6 +249,8 @@
       new_current_amount: "Novo valor atual"
       remaining: "Restante"
       submit: "Atualizar progresso"
+      amount_placeholder: "0,00"
+      quick_add: "+%{unit}%{amount}"
   common:
     actions:
       title: "Acoes"
@@ -248,8 +259,10 @@
       edit: "Editar"
       delete: "Excluir"
       view: "Ver"
+      dismiss: "Dispensar"
     confirmations:
       are_you_sure: "Tem certeza?"
+    loading: "Carregando..."
   helpers:
     submit:
       category:
@@ -267,6 +280,11 @@
       transaction: "Transacao"
       goal: "Meta"
     attributes:
+      user:
+        email: "E-mail"
+        password: "Senha"
+        password_confirmation: "Confirmacao de senha"
+        current_password: "Senha atual"
       category:
         name: "Nome"
         color: "Cor"
@@ -306,3 +324,70 @@
       deleted: "Meta removida com sucesso"
       progress_updated: "Progresso da meta atualizado com sucesso"
       progress_update_failed: "Nao foi possivel atualizar o progresso da meta"
+  jobs:
+    monitoring:
+      title: "Monitoramento de jobs"
+      subtitle: "Snapshot do processamento em background via Solid Queue."
+      status:
+        pending: "Pendente"
+        running: "Em execucao"
+        failed: "Falhou"
+        finished: "Finalizado"
+  mailers:
+    goal_notifications:
+      due_soon:
+        greeting: "Ola %{email},"
+        summary: "Sua meta \"%{title}\" vence em %{days} dia(s)."
+        current_progress: "Progresso atual: %{progress}"
+        target_amount: "Valor alvo: %{amount}"
+        current_amount: "Valor atual: %{amount}"
+        encouragement: "Continue assim!"
+    reports:
+      monthly_summary:
+        greeting: "Ola %{email},"
+        summary: "Aqui esta o seu resumo financeiro de %{month}:"
+        income: "Receitas: %{amount}"
+        expenses: "Despesas: %{amount}"
+        balance: "Saldo: %{amount}"
+        footer: "Gerado automaticamente pelo Finance App."
+  number:
+    currency:
+      format:
+        unit: "R$"
+        separator: ","
+        delimiter: "."
+        format: "%u %n"
+        negative_format: "-%u %n"
+        precision: 2
+  date:
+    formats:
+      short: "%d %b %Y"
+      long: "%d %B %Y"
+    month_names:
+      - ~
+      - "janeiro"
+      - "fevereiro"
+      - "marco"
+      - "abril"
+      - "maio"
+      - "junho"
+      - "julho"
+      - "agosto"
+      - "setembro"
+      - "outubro"
+      - "novembro"
+      - "dezembro"
+    abbr_month_names:
+      - ~
+      - "jan"
+      - "fev"
+      - "mar"
+      - "abr"
+      - "mai"
+      - "jun"
+      - "jul"
+      - "ago"
+      - "set"
+      - "out"
+      - "nov"
+      - "dez"

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -2,19 +2,17 @@
 # development, test). The code here should be idempotent so that it can be executed at any point in every environment.
 # The data can then be loaded with the bin/rails db:seed command (or created alongside the database with db:setup).
 
-# Create default categories for development/demo user
-if Rails.env.development?
-  # Find or create a demo user
-  demo_user = User.find_or_create_by!(email: "demo@example.com") do |user|
-    user.password = "password123"
-  end
+# Permanent seeded user for local/staging testing.
+SEED_USER_EMAIL = ENV.fetch("SEED_USER_EMAIL", "demo@example.com")
+SEED_USER_PASSWORD = ENV.fetch("SEED_USER_PASSWORD", "password123")
 
-  # Ensure password is always set correctly
-  unless demo_user.valid_password?("password123")
-    demo_user.update!(password: "password123")
-  end
+unless Rails.env.production?
+  demo_user = User.find_or_initialize_by(email: SEED_USER_EMAIL)
+  demo_user.password = SEED_USER_PASSWORD
+  demo_user.password_confirmation = SEED_USER_PASSWORD
+  demo_user.save!
 
-  puts "Demo user created: #{demo_user.email}"
+  puts "Seed user ready: #{demo_user.email}"
 
   # Create default categories with colors
   Category::DEFAULT_COLORS.each do |name, color|
@@ -25,7 +23,7 @@ if Rails.env.development?
   end
 
   puts "\nSeeding completed!"
-  puts "Demo user credentials: demo@example.com / password123"
+  puts "Seed user credentials: #{SEED_USER_EMAIL} / #{SEED_USER_PASSWORD}"
   puts "Total categories created: #{demo_user.categories.count}"
 
   # Load transaction seeds

--- a/db/seeds/transactions.rb
+++ b/db/seeds/transactions.rb
@@ -1,6 +1,6 @@
 puts "Creating sample transactions..."
 
-user = User.find_by(email: 'demo@example.com')
+user = User.find_by(email: SEED_USER_EMAIL)
 return unless user
 
 # Get categories
@@ -11,65 +11,70 @@ shopping_category = user.categories.find_by(name: 'Shopping')
 bills_category = user.categories.find_by(name: 'Bills')
 freelance_category = user.categories.find_by(name: 'Freelance')
 
-# Create income transactions
-user.transactions.create!(
-  amount: 5000,
-  transaction_type: 'income',
-  date: Date.current.beginning_of_month,
-  description: 'Monthly salary',
-  category: salary_category
-)
+transactions_data = [
+  {
+    amount: 5000,
+    transaction_type: "income",
+    date: Date.current.beginning_of_month,
+    description: "Monthly salary",
+    category: salary_category
+  },
+  {
+    amount: 800,
+    transaction_type: "income",
+    date: Date.current - 5.days,
+    description: "Freelance project payment",
+    category: freelance_category
+  },
+  {
+    amount: 45.50,
+    transaction_type: "expense",
+    date: Date.current - 1.day,
+    description: "Lunch at restaurant",
+    category: food_category
+  },
+  {
+    amount: 25.00,
+    transaction_type: "expense",
+    date: Date.current - 2.days,
+    description: "Uber ride to work",
+    category: transport_category
+  },
+  {
+    amount: 150.00,
+    transaction_type: "expense",
+    date: Date.current - 3.days,
+    description: "New shoes",
+    category: shopping_category
+  },
+  {
+    amount: 89.99,
+    transaction_type: "expense",
+    date: Date.current - 4.days,
+    description: "Internet bill",
+    category: bills_category
+  },
+  {
+    amount: 120.00,
+    transaction_type: "expense",
+    date: Date.current - 7.days,
+    description: "Groceries",
+    category: food_category
+  }
+]
 
-user.transactions.create!(
-  amount: 800,
-  transaction_type: 'income',
-  date: Date.current - 5.days,
-  description: 'Freelance project payment',
-  category: freelance_category
-)
-
-# Create expense transactions
-user.transactions.create!(
-  amount: 45.50,
-  transaction_type: 'expense',
-  date: Date.current - 1.day,
-  description: 'Lunch at restaurant',
-  category: food_category
-)
-
-user.transactions.create!(
-  amount: 25.00,
-  transaction_type: 'expense',
-  date: Date.current - 2.days,
-  description: 'Uber ride to work',
-  category: transport_category
-)
-
-user.transactions.create!(
-  amount: 150.00,
-  transaction_type: 'expense',
-  date: Date.current - 3.days,
-  description: 'New shoes',
-  category: shopping_category
-)
-
-user.transactions.create!(
-  amount: 89.99,
-  transaction_type: 'expense',
-  date: Date.current - 4.days,
-  description: 'Internet bill',
-  category: bills_category
-)
-
-user.transactions.create!(
-  amount: 120.00,
-  transaction_type: 'expense',
-  date: Date.current - 7.days,
-  description: 'Groceries',
-  category: food_category
-)
+transactions_data.each do |transaction_attrs|
+  user.transactions.find_or_create_by!(
+    description: transaction_attrs[:description],
+    date: transaction_attrs[:date]
+  ) do |transaction|
+    transaction.amount = transaction_attrs[:amount]
+    transaction.transaction_type = transaction_attrs[:transaction_type]
+    transaction.category = transaction_attrs[:category]
+  end
+end
 
 puts "Created #{user.transactions.count} sample transactions!"
-puts "Total income: $#{user.transactions.income.sum(:amount)}"
-puts "Total expenses: $#{user.transactions.expense.sum(:amount)}"
-puts "Balance: $#{user.transactions.balance}"
+puts "Total income: #{user.transactions.income.sum(:amount)}"
+puts "Total expenses: #{user.transactions.expense.sum(:amount)}"
+puts "Balance: #{user.transactions.balance}"

--- a/spec/config/i18n_configuration_spec.rb
+++ b/spec/config/i18n_configuration_spec.rb
@@ -1,8 +1,8 @@
 require "rails_helper"
 
 RSpec.describe "I18n configuration" do
-  it "uses pt-BR as the default locale" do
-    expect(I18n.default_locale).to eq(:"pt-BR")
+  it "uses en as the default locale" do
+    expect(I18n.default_locale).to eq(:en)
   end
 
   it "allows pt-BR and en locales" do

--- a/spec/config/i18n_configuration_spec.rb
+++ b/spec/config/i18n_configuration_spec.rb
@@ -1,0 +1,15 @@
+require "rails_helper"
+
+RSpec.describe "I18n configuration" do
+  it "uses pt-BR as the default locale" do
+    expect(I18n.default_locale).to eq(:"pt-BR")
+  end
+
+  it "allows pt-BR and en locales" do
+    expect(I18n.available_locales).to include(:"pt-BR", :en)
+  end
+
+  it "falls back to en when translation is missing" do
+    expect(I18n.fallbacks[:"pt-BR"]).to include(:en)
+  end
+end

--- a/spec/features/authentication_flow_spec.rb
+++ b/spec/features/authentication_flow_spec.rb
@@ -10,14 +10,14 @@ RSpec.describe "Authentication flow", type: :feature do
 
     fill_in "user_email", with: user.email
     fill_in "user_password", with: "password123"
-    click_button "Sign in"
+    click_button I18n.t("devise.views.sessions.new.submit")
 
     expect(page).to have_current_path("/transactions", ignore_query: true)
-    expect(page).to have_content("Signed in successfully")
+    expect(page).to have_content(I18n.t("devise.sessions.signed_in"))
 
-    click_button "Sign out", match: :first
+    click_button I18n.t("app.nav.sign_out"), match: :first
 
     expect(page).to have_current_path("/users/sign_in", ignore_query: true)
-    expect(page).to have_content("Signed out successfully")
+    expect(page).to have_content(I18n.t("devise.sessions.signed_out"))
   end
 end

--- a/spec/features/dashboard_interactions_spec.rb
+++ b/spec/features/dashboard_interactions_spec.rb
@@ -12,7 +12,7 @@ RSpec.describe "Dashboard interactions", type: :feature do
     visit "/users/sign_in"
     fill_in "user_email", with: user.email
     fill_in "user_password", with: "password123"
-    click_button "Sign in"
+    click_button I18n.t("devise.views.sessions.new.submit")
   end
 
   it "shows dashboard data and keeps filter params in export link" do

--- a/spec/features/dashboard_interactions_spec.rb
+++ b/spec/features/dashboard_interactions_spec.rb
@@ -21,7 +21,7 @@ RSpec.describe "Dashboard interactions", type: :feature do
     expect(page).to have_content("Dashboard")
     expect(page).to have_content("Coffee beans")
 
-    export_href = find_link("Export CSV")[:href]
+    export_href = find_link(I18n.t("dashboard.index.export_csv"))[:href]
     expect(export_href).to include("format=csv")
     expect(export_href).to include("transaction_type=expense")
     expect(export_href).to include("period=month")

--- a/spec/features/transactions_flow_spec.rb
+++ b/spec/features/transactions_flow_spec.rb
@@ -15,11 +15,11 @@ RSpec.describe "Transactions flow", type: :feature do
     visit "/transactions/new"
 
     choose I18n.t("transactions.form.income"), allow_label_click: true
-    fill_in "Amount", with: "123.45"
-    fill_in "Date", with: Date.current
+    fill_in I18n.t("activerecord.attributes.transaction.amount"), with: "123.45"
+    fill_in I18n.t("activerecord.attributes.transaction.date"), with: Date.current
     select "Salary", from: I18n.t("transactions.form.category")
-    fill_in "Description", with: "Capybara salary"
-    click_button "Create Transaction"
+    fill_in I18n.t("activerecord.attributes.transaction.description"), with: "Capybara salary"
+    click_button I18n.t("helpers.submit.transaction.create")
 
     expect(page).to have_content(I18n.t("notices.transactions.created"))
     expect(page).to have_content("Capybara salary")
@@ -27,8 +27,8 @@ RSpec.describe "Transactions flow", type: :feature do
     transaction = user.transactions.find_by!(description: "Capybara salary")
 
     visit "/transactions/#{transaction.id}/edit"
-    fill_in "Description", with: "Capybara salary updated"
-    click_button "Update Transaction"
+    fill_in I18n.t("activerecord.attributes.transaction.description"), with: "Capybara salary updated"
+    click_button I18n.t("helpers.submit.transaction.update")
 
     expect(page).to have_content(I18n.t("notices.transactions.updated"))
     expect(page).to have_content("Capybara salary updated")

--- a/spec/features/transactions_flow_spec.rb
+++ b/spec/features/transactions_flow_spec.rb
@@ -14,14 +14,14 @@ RSpec.describe "Transactions flow", type: :feature do
   it "creates and updates a transaction" do
     visit "/transactions/new"
 
-    choose "Income", allow_label_click: true
+    choose I18n.t("transactions.form.income"), allow_label_click: true
     fill_in "Amount", with: "123.45"
     fill_in "Date", with: Date.current
-    select "Salary", from: "Category"
+    select "Salary", from: I18n.t("transactions.form.category")
     fill_in "Description", with: "Capybara salary"
     click_button "Create Transaction"
 
-    expect(page).to have_content("Transaction was successfully created")
+    expect(page).to have_content(I18n.t("notices.transactions.created"))
     expect(page).to have_content("Capybara salary")
 
     transaction = user.transactions.find_by!(description: "Capybara salary")
@@ -30,7 +30,7 @@ RSpec.describe "Transactions flow", type: :feature do
     fill_in "Description", with: "Capybara salary updated"
     click_button "Update Transaction"
 
-    expect(page).to have_content("Transaction was successfully updated")
+    expect(page).to have_content(I18n.t("notices.transactions.updated"))
     expect(page).to have_content("Capybara salary updated")
   end
 end

--- a/spec/features/transactions_flow_spec.rb
+++ b/spec/features/transactions_flow_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe "Transactions flow", type: :feature do
     visit "/users/sign_in"
     fill_in "user_email", with: user.email
     fill_in "user_password", with: "password123"
-    click_button "Sign in"
+    click_button I18n.t("devise.views.sessions.new.submit")
   end
 
   it "creates and updates a transaction" do

--- a/spec/jobs/monthly_financial_report_job_spec.rb
+++ b/spec/jobs/monthly_financial_report_job_spec.rb
@@ -13,16 +13,27 @@ RSpec.describe MonthlyFinancialReportJob, type: :job do
     create(:transaction, :income, user: user, category: income_category, amount: 2500, date: Date.new(2026, 3, 5))
     create(:transaction, :expense, user: user, category: expense_category, amount: 700, date: Date.new(2026, 3, 10))
 
-    expect {
-      described_class.perform_now(user.id, "2026-03-01")
-    }.to change(ActionMailer::Base.deliveries, :count).by(1)
+    I18n.with_locale(:en) do
+      expect {
+        described_class.perform_now(user.id, "2026-03-01")
+      }.to change(ActionMailer::Base.deliveries, :count).by(1)
 
-    email = ActionMailer::Base.deliveries.last
-    expect(email.to).to contain_exactly(user.email)
-    expect(email.subject).to include("2026-03")
-    expect(email.body.encoded).to include("Income: R$ 2.500,00")
-    expect(email.body.encoded).to include("Expenses: R$ 700,00")
-    expect(email.body.encoded).to include("Balance: R$ 1.800,00")
+      email = ActionMailer::Base.deliveries.last
+      expect(email.to).to contain_exactly(user.email)
+      expect(email.subject).to include("2026-03")
+
+      currency = ActionController::Base.helpers.method(:number_to_currency)
+
+      expect(email.body.encoded).to include(
+        I18n.t("mailers.reports.monthly_summary.income", amount: currency.call(2500))
+      )
+      expect(email.body.encoded).to include(
+        I18n.t("mailers.reports.monthly_summary.expenses", amount: currency.call(700))
+      )
+      expect(email.body.encoded).to include(
+        I18n.t("mailers.reports.monthly_summary.balance", amount: currency.call(1800))
+      )
+    end
   end
 
   it "falls back to previous month when reference month is invalid" do

--- a/spec/models/currency_format_contract_spec.rb
+++ b/spec/models/currency_format_contract_spec.rb
@@ -1,14 +1,26 @@
 require "rails_helper"
 
 RSpec.describe "Currency format contract" do
-  it "keeps BRL currency defaults" do
-    formatted = ActionController::Base.helpers.number_to_currency(1234.56)
+  it "keeps USD currency defaults for en" do
+    formatted = I18n.with_locale(:en) do
+      ActionController::Base.helpers.number_to_currency(1234.56)
+    end
+
+    expect(formatted).to eq("$1,234.56")
+  end
+
+  it "keeps BRL currency defaults for pt-BR" do
+    formatted = I18n.with_locale(:"pt-BR") do
+      ActionController::Base.helpers.number_to_currency(1234.56)
+    end
 
     expect(formatted).to eq("R$ 1.234,56")
   end
 
   it "keeps negative BRL currency format" do
-    formatted = ActionController::Base.helpers.number_to_currency(-10)
+    formatted = I18n.with_locale(:"pt-BR") do
+      ActionController::Base.helpers.number_to_currency(-10)
+    end
 
     expect(formatted).to eq("-R$ 10,00")
   end

--- a/spec/models/transaction_spec.rb
+++ b/spec/models/transaction_spec.rb
@@ -32,12 +32,23 @@ RSpec.describe Transaction, type: :model do
     describe "#formatted_amount" do
       it "formats income with + sign" do
         transaction = create(:transaction, :income, amount: 100.50, user: user, category: category)
-        expect(transaction.formatted_amount).to eq("+R$ 100,50")
+
+        formatted = I18n.with_locale(:en) { transaction.formatted_amount }
+        expect(formatted).to eq("+$100.50")
       end
 
       it "formats expense with - sign" do
         transaction = create(:transaction, :expense, amount: 75.25, user: user, category: category)
-        expect(transaction.formatted_amount).to eq("-R$ 75,25")
+
+        formatted = I18n.with_locale(:en) { transaction.formatted_amount }
+        expect(formatted).to eq("-$75.25")
+      end
+
+      it "formats amounts using pt-BR locale" do
+        transaction = create(:transaction, :income, amount: 100.50, user: user, category: category)
+
+        formatted = I18n.with_locale(:"pt-BR") { transaction.formatted_amount }
+        expect(formatted).to eq("+R$ 100,50")
       end
     end
   end

--- a/spec/requests/transactions_authorization_spec.rb
+++ b/spec/requests/transactions_authorization_spec.rb
@@ -48,6 +48,6 @@ RSpec.describe "Transactions authorization", type: :request do
     get "/transactions/#{own_transaction.id}/edit"
 
     expect(response).to have_http_status(:ok)
-    expect(response.body).to include("Edit")
+    expect(response.body).to include(I18n.t("transactions.modal.edit_title"))
   end
 end


### PR DESCRIPTION
## Resumo
Implementa traducao progressiva para pt-BR cobrindo autenticacao, shell da aplicacao e os fluxos principais de produto.

## O que foi feito
- Locale padrao pt-BR com fallback para en e validacoes de i18n em dev/test
- Traducao de Devise (views + mailers) e navegacao/layout
- Traducao de Dashboard e Transacoes (filtros, tabelas, formularios e acoes)
- Traducao de Categorias e Metas (index, modais, formularios, cards, show e summaries)
- Mensagens de notice/confirmacoes via i18n
- Chaves espelhadas em en para fallback consistente

## Validacao
- RSpec completo: 76 examples, 0 failures
- RuboCop: sem offenses
- Brakeman: 0 warnings

## Issue
- Closes #79
