### PR TITLE
feat: compare current and previous month on dashboard

### DIFF
--- a/app/controllers/dashboard_controller.rb
+++ b/app/controllers/dashboard_controller.rb
@@ -21,6 +21,7 @@ class DashboardController < ApplicationController
     @income_vs_expenses_data = charts_data[:income_vs_expenses]
     @expenses_by_category_data = charts_data[:expenses_by_category]
     @monthly_evolution_data = Dashboard::MonthlyEvolutionData.new(scope: unbounded_chart_transactions).call
+    @month_comparison = Dashboard::MonthComparisonData.new(scope: @user.transactions).call
 
     respond_to do |format|
       format.html

--- a/app/services/dashboard/month_comparison_data.rb
+++ b/app/services/dashboard/month_comparison_data.rb
@@ -1,0 +1,83 @@
+module Dashboard
+  class MonthComparisonData
+    METRICS = {
+      income: "Income",
+      expenses: "Expenses",
+      balance: "Balance"
+    }.freeze
+
+    def initialize(scope:, reference_date: Date.current)
+      @scope = scope
+      @reference_date = reference_date.to_date
+    end
+
+    def call
+      {
+        current_month_label: current_month.strftime("%b %Y"),
+        previous_month_label: previous_month.strftime("%b %Y"),
+        metrics: build_metrics
+      }
+    end
+
+    private
+
+    def build_metrics
+      current_totals = totals_for(current_month)
+      previous_totals = totals_for(previous_month)
+
+      METRICS.each_with_object({}) do |(key, label), metrics|
+        metrics[key] = build_metric(
+          label: label,
+          current_amount: current_totals.fetch(key, 0),
+          previous_amount: previous_totals.fetch(key, 0)
+        )
+      end
+    end
+
+    def build_metric(label:, current_amount:, previous_amount:)
+      absolute_change = current_amount - previous_amount
+
+      {
+        label: label,
+        current_amount: current_amount,
+        previous_amount: previous_amount,
+        absolute_change: absolute_change,
+        percentage_change: percentage_change_for(current_amount, previous_amount),
+        direction: direction_for(absolute_change)
+      }
+    end
+
+    def totals_for(month)
+      grouped = @scope.where(date: month.all_month).group(:transaction_type).sum(:amount)
+      income = grouped.fetch("income", 0)
+      expenses = grouped.fetch("expense", 0)
+
+      {
+        income: income,
+        expenses: expenses,
+        balance: income - expenses
+      }
+    end
+
+    def percentage_change_for(current_amount, previous_amount)
+      return nil if previous_amount.zero?
+
+      ((current_amount - previous_amount) / previous_amount.to_f) * 100
+    end
+
+    def direction_for(amount)
+      return :up if amount.positive?
+      return :down if amount.negative?
+
+      :flat
+    end
+
+    def current_month
+      @reference_date.beginning_of_month
+    end
+
+    def previous_month
+      current_month.prev_month
+    end
+  end
+end

--- a/app/views/dashboard/index.html.erb
+++ b/app/views/dashboard/index.html.erb
@@ -24,7 +24,7 @@
     </div>
     
     <div id="balance_summary" class="mt-8">
-      <%= render "shared/balance_summary", user: @user %>
+      <%= render "shared/balance_summary", user: @user, comparison: @month_comparison %>
     </div>
 
     <!-- Goals Summary in separate frame -->

--- a/app/views/shared/_balance_summary.html.erb
+++ b/app/views/shared/_balance_summary.html.erb
@@ -5,6 +5,24 @@
         data-balance-target="amount">
       <%= number_to_currency(user.total_income) %>
     </dd>
+    <% if local_assigns[:comparison].present? %>
+      <% income_metric = comparison[:metrics][:income] %>
+      <% income_good = income_metric[:direction] != :down %>
+      <div class="mt-3 text-sm">
+        <p class="text-gray-500 dark:text-gray-400">
+          <%= comparison[:current_month_label] %> vs <%= comparison[:previous_month_label] %>
+        </p>
+        <p class="<%= income_good ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %> font-medium">
+          <%= income_metric[:direction] == :up ? "Up" : income_metric[:direction] == :down ? "Down" : "Flat" %>
+          <%= number_to_currency(income_metric[:absolute_change].abs) %>
+          <% if income_metric[:percentage_change].present? %>
+            (<%= number_to_percentage(income_metric[:percentage_change].abs, precision: 1) %>)
+          <% else %>
+            (new period)
+          <% end %>
+        </p>
+      </div>
+    <% end %>
   </div>
   
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6 transition-all duration-300 hover:shadow-md">
@@ -13,6 +31,24 @@
         data-balance-target="amount">
       <%= number_to_currency(user.total_expenses) %>
     </dd>
+    <% if local_assigns[:comparison].present? %>
+      <% expenses_metric = comparison[:metrics][:expenses] %>
+      <% expenses_good = expenses_metric[:direction] != :up %>
+      <div class="mt-3 text-sm">
+        <p class="text-gray-500 dark:text-gray-400">
+          <%= comparison[:current_month_label] %> vs <%= comparison[:previous_month_label] %>
+        </p>
+        <p class="<%= expenses_good ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %> font-medium">
+          <%= expenses_metric[:direction] == :up ? "Up" : expenses_metric[:direction] == :down ? "Down" : "Flat" %>
+          <%= number_to_currency(expenses_metric[:absolute_change].abs) %>
+          <% if expenses_metric[:percentage_change].present? %>
+            (<%= number_to_percentage(expenses_metric[:percentage_change].abs, precision: 1) %>)
+          <% else %>
+            (new period)
+          <% end %>
+        </p>
+      </div>
+    <% end %>
   </div>
   
   <div class="overflow-hidden rounded-lg bg-white dark:bg-gray-800 px-4 py-5 shadow sm:p-6 transition-all duration-300 hover:shadow-md">
@@ -21,5 +57,23 @@
         data-balance-target="amount">
       <%= number_to_currency(user.balance) %>
     </dd>
+    <% if local_assigns[:comparison].present? %>
+      <% balance_metric = comparison[:metrics][:balance] %>
+      <% balance_good = balance_metric[:direction] != :down %>
+      <div class="mt-3 text-sm">
+        <p class="text-gray-500 dark:text-gray-400">
+          <%= comparison[:current_month_label] %> vs <%= comparison[:previous_month_label] %>
+        </p>
+        <p class="<%= balance_good ? 'text-green-600 dark:text-green-400' : 'text-red-600 dark:text-red-400' %> font-medium">
+          <%= balance_metric[:direction] == :up ? "Up" : balance_metric[:direction] == :down ? "Down" : "Flat" %>
+          <%= number_to_currency(balance_metric[:absolute_change].abs) %>
+          <% if balance_metric[:percentage_change].present? %>
+            (<%= number_to_percentage(balance_metric[:percentage_change].abs, precision: 1) %>)
+          <% else %>
+            (new period)
+          <% end %>
+        </p>
+      </div>
+    <% end %>
   </div>
 </div>

--- a/spec/features/dashboard_interactions_spec.rb
+++ b/spec/features/dashboard_interactions_spec.rb
@@ -20,11 +20,13 @@ RSpec.describe "Dashboard interactions", type: :feature do
   it "shows dashboard data and keeps filter params in export link" do
     visit "/dashboard?transaction_type=expense&period=month"
 
+    currency = ActionController::Base.helpers.method(:number_to_currency)
+
     expect(page).to have_content("Dashboard")
     expect(page).to have_content("Coffee beans")
     expect(page).to have_content("vs")
-    expect(page).to have_content("Up R$ 500,00")
-    expect(page).to have_content("Down R$ 30,00")
+    expect(page).to have_content("Up #{currency.call(500)}")
+    expect(page).to have_content("Down #{currency.call(30)}")
 
     export_href = find_link("Export CSV")[:href]
     expect(export_href).to include("format=csv")

--- a/spec/features/dashboard_interactions_spec.rb
+++ b/spec/features/dashboard_interactions_spec.rb
@@ -8,6 +8,8 @@ RSpec.describe "Dashboard interactions", type: :feature do
   before do
     create(:transaction, :expense, user: user, category: expense_category, amount: 20, description: "Coffee beans", date: Date.current)
     create(:transaction, :income, user: user, category: income_category, amount: 2000, description: "Monthly salary", date: Date.current)
+    create(:transaction, :income, user: user, category: income_category, amount: 1500, description: "Previous month salary", date: 1.month.ago.beginning_of_month + 2.days)
+    create(:transaction, :expense, user: user, category: expense_category, amount: 50, description: "Previous month groceries", date: 1.month.ago.beginning_of_month + 4.days)
 
     visit "/users/sign_in"
     fill_in "user_email", with: user.email
@@ -20,6 +22,9 @@ RSpec.describe "Dashboard interactions", type: :feature do
 
     expect(page).to have_content("Dashboard")
     expect(page).to have_content("Coffee beans")
+    expect(page).to have_content("vs")
+    expect(page).to have_content("Up R$ 500,00")
+    expect(page).to have_content("Down R$ 30,00")
 
     export_href = find_link("Export CSV")[:href]
     expect(export_href).to include("format=csv")

--- a/spec/services/dashboard/month_comparison_data_spec.rb
+++ b/spec/services/dashboard/month_comparison_data_spec.rb
@@ -1,0 +1,54 @@
+require "rails_helper"
+
+RSpec.describe Dashboard::MonthComparisonData, type: :service do
+  let(:user) { create(:user) }
+  let(:income_category) { create(:category, user: user, name: "Salary") }
+  let(:expense_category) { create(:category, user: user, name: "Food") }
+  let(:reference_date) { Date.new(2026, 4, 15) }
+
+  it "returns current and previous month values with absolute and percentage deltas" do
+    create(:transaction, :income, user: user, category: income_category, amount: 3000, date: Date.new(2026, 4, 3))
+    create(:transaction, :expense, user: user, category: expense_category, amount: 900, date: Date.new(2026, 4, 8))
+    create(:transaction, :income, user: user, category: income_category, amount: 2400, date: Date.new(2026, 3, 4))
+    create(:transaction, :expense, user: user, category: expense_category, amount: 600, date: Date.new(2026, 3, 10))
+
+    result = described_class.new(scope: user.transactions, reference_date: reference_date).call
+
+    expect(result[:current_month_label]).to eq("Apr 2026")
+    expect(result[:previous_month_label]).to eq("Mar 2026")
+
+    expect(result[:metrics][:income]).to include(
+      current_amount: 3000,
+      previous_amount: 2400,
+      absolute_change: 600,
+      direction: :up
+    )
+    expect(result[:metrics][:income][:percentage_change]).to be_within(0.01).of(25.0)
+
+    expect(result[:metrics][:expenses]).to include(
+      current_amount: 900,
+      previous_amount: 600,
+      absolute_change: 300,
+      direction: :up
+    )
+    expect(result[:metrics][:expenses][:percentage_change]).to be_within(0.01).of(50.0)
+
+    expect(result[:metrics][:balance]).to include(
+      current_amount: 2100,
+      previous_amount: 1800,
+      absolute_change: 300,
+      direction: :up
+    )
+    expect(result[:metrics][:balance][:percentage_change]).to be_within(0.01).of(16.66)
+  end
+
+  it "returns nil percentage when there is no previous month data" do
+    create(:transaction, :income, user: user, category: income_category, amount: 1500, date: Date.new(2026, 4, 3))
+
+    result = described_class.new(scope: user.transactions, reference_date: reference_date).call
+
+    expect(result[:metrics][:income][:previous_amount]).to eq(0)
+    expect(result[:metrics][:income][:percentage_change]).to be_nil
+    expect(result[:metrics][:income][:direction]).to eq(:up)
+  end
+end


### PR DESCRIPTION
## Summary

- add monthly comparison data for income, expenses, and balance on the dashboard
- show absolute and percentage change versus the previous month with visual trend cues
- display explicit current-month and previous-month values in each indicator card
- localize trend labels and fallback text for periods without previous-month data
- cover comparison calculations and dashboard rendering with tests

## Validation

- `docker compose exec -e RAILS_ENV=test web bundle exec rspec spec/services/dashboard/month_comparison_data_spec.rb spec/features/dashboard_interactions_spec.rb`

Closes #77
