### PR TITLE
feat: Metas recorrentes mensais com rollover automático (#74)

### DIFF
--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -3,7 +3,14 @@ class GoalsController < ApplicationController
 
   # GET /goals
   def index
+    @showing_history = params[:history] == "true"
     @goals = Current.user.goals.includes(:category).ordered
+
+    if @showing_history
+      @goals = @goals.history
+    else
+      @goals = @goals.where.not(status: "rolled_over")
+    end
 
     @goals = filter_goals(@goals) if filtering_params.values.any?(&:present?)
 
@@ -158,11 +165,11 @@ class GoalsController < ApplicationController
 
   def goal_params
     params.require(:goal).permit(:title, :description, :target_amount, :current_amount,
-                                 :target_date, :goal_type, :status, :category_id)
+                                 :target_date, :goal_type, :status, :category_id, :recurring)
   end
 
   def filtering_params
-    params.permit(:status, :goal_type, :search)
+    params.permit(:status, :goal_type, :search, :history)
   end
 
   def filter_goals(goals)

--- a/app/controllers/goals_controller.rb
+++ b/app/controllers/goals_controller.rb
@@ -12,7 +12,7 @@ class GoalsController < ApplicationController
       @goals = @goals.where.not(status: "rolled_over")
     end
 
-    @goals = filter_goals(@goals) if filtering_params.values.any?(&:present?)
+    @goals = filter_goals(@goals) if params[:goal_type].present? || params[:search].present? || (!@showing_history && params[:status].present?)
 
     respond_to do |format|
       format.html

--- a/app/jobs/process_goal_rollovers_job.rb
+++ b/app/jobs/process_goal_rollovers_job.rb
@@ -1,0 +1,7 @@
+class ProcessGoalRolloversJob < ApplicationJob
+  queue_as :default
+
+  def perform
+    Goal.pending_rollover.find_each(&:rollover!)
+  end
+end

--- a/app/models/concerns/progressable.rb
+++ b/app/models/concerns/progressable.rb
@@ -60,6 +60,6 @@ module Progressable
   def check_completion_status
     return unless respond_to?(:can_complete?) && respond_to?(:mark_completed!)
 
-    mark_completed! if can_complete? && respond_to?(:status) && status != "completed"
+    mark_completed! if can_complete? && respond_to?(:status) && !%w[completed rolled_over].include?(status)
   end
 end

--- a/app/models/goal.rb
+++ b/app/models/goal.rb
@@ -5,6 +5,8 @@ class Goal < ApplicationRecord
   # Associations
   belongs_to :user
   belongs_to :category, optional: true
+  belongs_to :parent_goal, class_name: "Goal", optional: true
+  has_many :child_goals, class_name: "Goal", foreign_key: :parent_goal_id, dependent: :nullify
 
   # Enums
   enum :goal_type, {
@@ -18,8 +20,12 @@ class Goal < ApplicationRecord
     active: "active",
     completed: "completed",
     paused: "paused",
-    cancelled: "cancelled"
+    cancelled: "cancelled",
+    rolled_over: "rolled_over"
   }
+
+  # Callbacks
+  before_create :set_period_dates_if_recurring
 
   # Validations
   validates :title, presence: true, length: { maximum: 255 }
@@ -39,6 +45,9 @@ class Goal < ApplicationRecord
   scope :completed_goals, -> { where(status: "completed") }
   scope :overdue, -> { where("target_date < ? AND status = ?", Date.current, "active") }
   scope :due_soon, -> { where(target_date: Date.current..1.week.from_now, status: "active") }
+  scope :recurring_goals, -> { where(recurring: true) }
+  scope :history, -> { where(status: "rolled_over") }
+  scope :pending_rollover, -> { recurring_goals.active.where("period_end < ?", Date.current) }
 
   # Instance methods
 
@@ -67,6 +76,39 @@ class Goal < ApplicationRecord
     (target_date - Date.current).to_i
   end
 
+  def rollover!
+    return false unless recurring? && active?
+
+    next_month_start = (period_end || Date.current).next_month.beginning_of_month
+    next_month_end   = next_month_start.end_of_month
+    root_id = parent_goal_id || id
+
+    new_goal = self.class.create!(
+      title: title,
+      description: description,
+      target_amount: target_amount,
+      current_amount: 0.0,
+      goal_type: goal_type,
+      category_id: category_id,
+      user_id: user_id,
+      recurring: true,
+      parent_goal_id: root_id,
+      period_start: next_month_start,
+      period_end: next_month_end,
+      target_date: next_month_end,
+      status: "active"
+    )
+
+    update!(status: "rolled_over")
+    new_goal
+  end
+
+  def current_period_label
+    return nil unless period_start && period_end
+
+    period_start.strftime("%b/%Y")
+  end
+
   def goal_type_color
     {
       "savings" => "emerald",
@@ -81,11 +123,20 @@ class Goal < ApplicationRecord
       "active" => "blue",
       "completed" => "green",
       "paused" => "yellow",
-      "cancelled" => "gray"
+      "cancelled" => "gray",
+      "rolled_over" => "slate"
     }[status] || "gray"
   end
 
   private
+
+  def set_period_dates_if_recurring
+    return unless recurring? && period_start.nil?
+
+    ref = target_date || Date.current
+    self.period_start = ref.beginning_of_month
+    self.period_end   = ref.end_of_month
+  end
 
   def target_date_cannot_be_in_the_past
     return unless target_date.present? && target_date < Date.current

--- a/app/views/goals/_form.html.erb
+++ b/app/views/goals/_form.html.erb
@@ -118,10 +118,21 @@
       <!-- Description -->
       <div>
         <%= f.label :description, class: "block text-sm font-medium text-gray-700 dark:text-gray-300 mb-2" %>
-        <%= f.text_area :description, 
+        <%= f.text_area :description,
             rows: 4,
             class: "w-full px-3 py-2 border border-gray-300 dark:border-gray-600 rounded-md focus:ring-blue-500 focus:border-blue-500 dark:bg-gray-700 dark:text-white resize-none",
           placeholder: t("goals.form.description_placeholder") %>
+      </div>
+
+      <!-- Recurring -->
+      <div class="flex items-start gap-3 p-4 bg-indigo-50 dark:bg-indigo-900/20 rounded-lg border border-indigo-200 dark:border-indigo-700">
+        <%= f.check_box :recurring,
+            class: "mt-0.5 h-4 w-4 text-indigo-600 border-gray-300 rounded focus:ring-indigo-500",
+            id: "goal_recurring" %>
+        <div>
+          <%= f.label :recurring, t("goals.form.recurring"), class: "block text-sm font-medium text-gray-700 dark:text-gray-300" %>
+          <p class="text-xs text-gray-500 dark:text-gray-400 mt-0.5"><%= t("goals.form.recurring_hint") %></p>
+        </div>
       </div>
 
       <!-- Form Actions -->

--- a/app/views/goals/_goal_card.html.erb
+++ b/app/views/goals/_goal_card.html.erb
@@ -13,16 +13,23 @@
         <% end %>
       </div>
       
-      <div class="flex gap-2 ml-4">
+      <div class="flex flex-wrap gap-2 ml-4">
         <!-- Goal Type Badge -->
         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-<%= goal.goal_type_color %>-100 text-<%= goal.goal_type_color %>-800 dark:bg-<%= goal.goal_type_color %>-800 dark:text-<%= goal.goal_type_color %>-100">
           <%= t("goals.types.#{goal.goal_type}") %>
         </span>
-        
+
         <!-- Status Badge -->
         <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-<%= goal.status_color %>-100 text-<%= goal.status_color %>-800 dark:bg-<%= goal.status_color %>-800 dark:text-<%= goal.status_color %>-100">
           <%= t("goals.status.#{goal.status}") %>
         </span>
+
+        <!-- Recurring Badge -->
+        <% if goal.recurring? %>
+          <span class="inline-flex items-center px-2 py-1 rounded-full text-xs font-medium bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-100">
+            ↻ <%= t("goals.card.recurring") %>
+          </span>
+        <% end %>
       </div>
     </div>
 
@@ -82,9 +89,17 @@
 
     <!-- Category -->
     <% if goal.category %>
-      <div class="flex items-center text-sm text-gray-600 dark:text-gray-400 mb-4">
+      <div class="flex items-center text-sm text-gray-600 dark:text-gray-400 mb-2">
         <div class="w-3 h-3 rounded-full mr-2" style="background-color: <%= goal.category.color %>"></div>
         <%= goal.category.name %>
+      </div>
+    <% end %>
+
+    <!-- Period (recurring only) -->
+    <% if goal.recurring? && goal.current_period_label %>
+      <div class="flex items-center text-sm text-gray-500 dark:text-gray-400">
+        <span class="font-medium"><%= t("goals.card.period") %>:</span>
+        <span class="ml-1"><%= goal.current_period_label %></span>
       </div>
     <% end %>
   </div>

--- a/app/views/goals/_goal_card.html.erb
+++ b/app/views/goals/_goal_card.html.erb
@@ -111,13 +111,15 @@
         <%= link_to t("common.actions.view"), goal_path(goal),
             class: "text-blue-600 dark:text-blue-400 hover:text-blue-800 dark:hover:text-blue-300 text-sm font-medium transition-colors",
             data: { turbo_frame: "_top" } %>
-        
-        <%= link_to t("common.actions.edit"), edit_goal_path(goal),
-            class: "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm font-medium transition-colors",
-            data: { turbo_frame: "goal_modal" } %>
+
+        <% unless goal.rolled_over? %>
+          <%= link_to t("common.actions.edit"), edit_goal_path(goal),
+              class: "text-gray-600 dark:text-gray-400 hover:text-gray-800 dark:hover:text-gray-200 text-sm font-medium transition-colors",
+              data: { turbo_frame: "goal_modal" } %>
+        <% end %>
       </div>
-      
-      <% unless goal.completed? %>
+
+      <% unless goal.completed? || goal.rolled_over? %>
         <%= link_to t("goals.card.update_progress"), update_progress_goal_path(goal),
             class: "text-green-600 dark:text-green-400 hover:text-green-800 dark:hover:text-green-300 text-sm font-medium transition-colors",
             data: { 

--- a/app/views/goals/index.html.erb
+++ b/app/views/goals/index.html.erb
@@ -7,7 +7,15 @@
           <%= t("goals.index.subtitle") %>
         </p>
       </div>
-      <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none">
+      <div class="mt-4 sm:mt-0 sm:ml-16 sm:flex-none flex items-center gap-3">
+        <% if @showing_history %>
+          <%= link_to t("goals.index.view_active"), goals_path,
+              class: "text-sm font-medium text-indigo-600 dark:text-indigo-400 hover:underline" %>
+        <% else %>
+          <%= link_to t("goals.index.view_history"), goals_path(history: true),
+              class: "text-sm font-medium text-gray-500 dark:text-gray-400 hover:text-gray-700 dark:hover:text-gray-200" %>
+        <% end %>
+
         <%= link_to t("goals.index.new_goal"), new_goal_path,
             class: "inline-flex items-center justify-center rounded-md border border-transparent bg-indigo-600 dark:bg-indigo-500 px-4 py-2 text-sm font-medium text-white shadow-sm hover:bg-indigo-700 dark:hover:bg-indigo-600 focus:outline-none focus:ring-2 focus:ring-indigo-500 focus:ring-offset-2 dark:focus:ring-offset-gray-800 sm:w-auto",
             data: { turbo_frame: "goal_modal" } %>

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -22,6 +22,12 @@
             <%= t("goals.status.#{@goal.status}") %>
           </span>
 
+          <% if @goal.recurring? %>
+            <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-medium bg-purple-100 text-purple-800 dark:bg-purple-800 dark:text-purple-100">
+              ↻ <%= t("goals.card.recurring") %>
+            </span>
+          <% end %>
+
           <% if @goal.overdue? %>
             <span class="inline-flex items-center px-2.5 py-1 rounded-full text-sm font-medium bg-red-100 text-red-800 dark:bg-red-800 dark:text-red-100">
               <%= t("goals.card.overdue") %>
@@ -142,6 +148,13 @@
             </div>
           <% end %>
           
+          <% if @goal.recurring? && @goal.current_period_label %>
+            <div>
+              <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.card.period") %></dt>
+              <dd class="mt-1 text-sm text-gray-900 dark:text-white"><%= @goal.current_period_label %></dd>
+            </div>
+          <% end %>
+
           <div>
             <dt class="text-sm font-medium text-gray-500 dark:text-gray-400"><%= t("goals.show.created") %></dt>
             <dd class="mt-1 text-sm text-gray-900 dark:text-white">
@@ -150,6 +163,28 @@
           </div>
         </div>
       </div>
+
+      <!-- Cycle History (recurring goals) -->
+      <% root_id = @goal.parent_goal_id || @goal.id %>
+      <% past_cycles = Goal.where(parent_goal_id: root_id).history.order(period_start: :desc) %>
+      <% if @goal.recurring? && past_cycles.any? %>
+        <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">
+          <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("goals.card.cycle_history") %></h3>
+          <ul class="space-y-3">
+            <% past_cycles.each do |cycle| %>
+              <li class="flex items-center justify-between text-sm">
+                <%= link_to cycle.current_period_label || localized_date(cycle.period_start),
+                    goal_path(cycle),
+                    class: "text-indigo-600 dark:text-indigo-400 hover:underline font-medium",
+                    data: { turbo_frame: "_top" } %>
+                <span class="text-gray-500 dark:text-gray-400">
+                  <%= number_to_percentage(cycle.progress_percentage, precision: 0) %>
+                </span>
+              </li>
+            <% end %>
+          </ul>
+        </div>
+      <% end %>
 
       <!-- Actions -->
       <div class="bg-white dark:bg-gray-800 rounded-lg shadow-sm border border-gray-200 dark:border-gray-700 p-6">

--- a/app/views/goals/show.html.erb
+++ b/app/views/goals/show.html.erb
@@ -42,14 +42,16 @@
     </div>
     
     <div class="flex gap-3">
-      <%= link_to t("goals.show.edit_goal"), edit_goal_path(@goal),
-          class: "inline-flex items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors",
-          data: { turbo_frame: "goal_modal" } %>
-      
-      <% unless @goal.completed? %>
+      <% unless @goal.rolled_over? %>
+        <%= link_to t("goals.show.edit_goal"), edit_goal_path(@goal),
+            class: "inline-flex items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors",
+            data: { turbo_frame: "goal_modal" } %>
+      <% end %>
+
+      <% unless @goal.completed? || @goal.rolled_over? %>
         <%= link_to t("goals.show.update_progress"), update_progress_goal_path(@goal),
             class: "inline-flex items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors",
-            data: { 
+            data: {
               turbo_frame: "goal_modal",
               turbo_stream: true
             } %>
@@ -191,19 +193,21 @@
         <h3 class="text-lg font-semibold text-gray-900 dark:text-white mb-4"><%= t("common.actions.title") %></h3>
         
         <div class="space-y-3">
-          <% unless @goal.completed? %>
+          <% unless @goal.completed? || @goal.rolled_over? %>
             <%= link_to t("goals.show.update_progress"), update_progress_goal_path(@goal),
                 class: "w-full inline-flex justify-center items-center px-4 py-2 bg-blue-600 hover:bg-blue-700 text-white font-medium rounded-lg transition-colors",
-                data: { 
+                data: {
                   turbo_frame: "goal_modal",
                   turbo_stream: true
                 } %>
           <% end %>
-          
-          <%= link_to t("goals.show.edit_goal"), edit_goal_path(@goal),
-              class: "w-full inline-flex justify-center items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors",
-              data: { turbo_frame: "goal_modal" } %>
-          
+
+          <% unless @goal.rolled_over? %>
+            <%= link_to t("goals.show.edit_goal"), edit_goal_path(@goal),
+                class: "w-full inline-flex justify-center items-center px-4 py-2 bg-gray-600 hover:bg-gray-700 text-white font-medium rounded-lg transition-colors",
+                data: { turbo_frame: "goal_modal" } %>
+          <% end %>
+
           <%= link_to t("goals.show.delete_goal"), goal_path(@goal),
               method: :delete,
               class: "w-full inline-flex justify-center items-center px-4 py-2 bg-red-600 hover:bg-red-700 text-white font-medium rounded-lg transition-colors",

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -261,6 +261,8 @@ en:
       title: "Goals"
       subtitle: "Track and manage your financial objectives"
       new_goal: "New goal"
+      view_history: "View history"
+      view_active: "← Active goals"
       filters:
         search_placeholder: "Search goals..."
         all_status: "All Status"
@@ -275,6 +277,7 @@ en:
       paused: "Paused"
       completed: "Completed"
       cancelled: "Cancelled"
+      rolled_over: "Rolled Over"
     form:
       errors:
         one: "There was 1 error with your submission"
@@ -288,6 +291,8 @@ en:
       current_amount_placeholder: "0.00"
       update_goal: "Update Goal"
       create_goal: "Create Goal"
+      recurring: "Monthly recurring goal"
+      recurring_hint: "A new cycle will be created automatically at the start of each month."
     modal:
       new_title: "New Goal"
       edit_title: "Edit Goal"
@@ -304,6 +309,9 @@ en:
         one: "1 day"
         other: "%{count} days"
       update_progress: "Update Progress"
+      recurring: "Recurring"
+      period: "Period"
+      cycle_history: "Cycle History"
     summary:
       overview: "Goals Overview"
       view_all: "View All Goals"

--- a/config/locales/pt-BR.yml
+++ b/config/locales/pt-BR.yml
@@ -237,6 +237,8 @@
       title: "Metas"
       subtitle: "Acompanhe e gerencie seus objetivos financeiros"
       new_goal: "Nova meta"
+      view_history: "Ver histórico"
+      view_active: "← Metas ativas"
       filters:
         search_placeholder: "Buscar metas..."
         all_status: "Todos os status"
@@ -251,6 +253,7 @@
       paused: "Pausada"
       completed: "Concluída"
       cancelled: "Cancelada"
+      rolled_over: "Encerrado (rollover)"
     form:
       errors:
         one: "Houve 1 erro no envio"
@@ -264,6 +267,8 @@
       current_amount_placeholder: "0,00"
       update_goal: "Atualizar meta"
       create_goal: "Criar meta"
+      recurring: "Meta recorrente mensal"
+      recurring_hint: "Um novo ciclo será criado automaticamente no início de cada mês."
     modal:
       new_title: "Nova meta"
       edit_title: "Editar meta"
@@ -280,6 +285,9 @@
         one: "1 dia"
         other: "%{count} dias"
       update_progress: "Atualizar progresso"
+      recurring: "Recorrente"
+      period: "Período"
+      cycle_history: "Histórico de ciclos"
     summary:
       overview: "Visão geral das metas"
       view_all: "Ver todas"

--- a/db/migrate/20260502212707_add_recurring_to_goals.rb
+++ b/db/migrate/20260502212707_add_recurring_to_goals.rb
@@ -1,0 +1,11 @@
+class AddRecurringToGoals < ActiveRecord::Migration[8.0]
+  def change
+    add_column :goals, :recurring, :boolean, default: false, null: false
+    add_column :goals, :parent_goal_id, :bigint
+    add_column :goals, :period_start, :date
+    add_column :goals, :period_end, :date
+
+    add_foreign_key :goals, :goals, column: :parent_goal_id
+    add_index :goals, :parent_goal_id
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[8.1].define(version: 2026_04_14_223600) do
+ActiveRecord::Schema[8.1].define(version: 2026_05_02_212707) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "pg_catalog.plpgsql"
   enable_extension "pg_trgm"
@@ -32,6 +32,10 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_223600) do
     t.decimal "current_amount", precision: 10, scale: 2, default: "0.0", null: false
     t.text "description"
     t.string "goal_type", null: false
+    t.bigint "parent_goal_id"
+    t.date "period_end"
+    t.date "period_start"
+    t.boolean "recurring", default: false, null: false
     t.string "status", default: "active", null: false
     t.decimal "target_amount", precision: 10, scale: 2, null: false
     t.date "target_date", null: false
@@ -39,6 +43,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_223600) do
     t.datetime "updated_at", null: false
     t.bigint "user_id", null: false
     t.index ["category_id"], name: "index_goals_on_category_id"
+    t.index ["parent_goal_id"], name: "index_goals_on_parent_goal_id"
     t.index ["user_id", "goal_type"], name: "index_goals_on_user_id_and_goal_type"
     t.index ["user_id", "status"], name: "index_goals_on_user_id_and_status"
     t.index ["user_id", "target_date"], name: "index_goals_on_user_id_and_target_date"
@@ -99,6 +104,7 @@ ActiveRecord::Schema[8.1].define(version: 2026_04_14_223600) do
 
   add_foreign_key "categories", "users"
   add_foreign_key "goals", "categories"
+  add_foreign_key "goals", "goals", column: "parent_goal_id"
   add_foreign_key "goals", "users"
   add_foreign_key "tags", "users"
   add_foreign_key "transaction_tags", "tags"

--- a/docker-compose.override.yml
+++ b/docker-compose.override.yml
@@ -1,0 +1,11 @@
+services:
+  db:
+    ports:
+      - "5434:5432"
+    environment:
+      POSTGRES_DB: finance_app_issue74_development
+  web:
+    ports:
+      - "3001:3000"
+    environment:
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/finance_app_issue74_development

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -6,9 +6,9 @@ services:
     environment:
       POSTGRES_USER: postgres
       POSTGRES_PASSWORD: postgres
-      POSTGRES_DB: finance_app_development
+      POSTGRES_DB: finance_app_issue74_development
     ports:
-      - "5433:5432"
+      - "5434:5432"
     healthcheck:
       test: ["CMD-SHELL", "pg_isready -U postgres"]
       interval: 10s
@@ -29,7 +29,7 @@ services:
       db:
         condition: service_healthy
     environment:
-      DATABASE_URL: postgresql://postgres:postgres@db:5432/finance_app_development
+      DATABASE_URL: postgresql://postgres:postgres@db:5432/finance_app_issue74_development
       RAILS_ENV: development
       RAILS_LOG_TO_STDOUT: 'true'
     stdin_open: true

--- a/lib/tasks/goals.rake
+++ b/lib/tasks/goals.rake
@@ -1,0 +1,6 @@
+namespace :goals do
+  desc "Process monthly rollover for recurring goals"
+  task process_rollovers: :environment do
+    ProcessGoalRolloversJob.perform_now
+  end
+end

--- a/spec/factories/goals.rb
+++ b/spec/factories/goals.rb
@@ -64,5 +64,24 @@ FactoryBot.define do
     trait :without_category do
       category { nil }
     end
+
+    trait :recurring do
+      recurring { true }
+      period_start { Date.current.beginning_of_month }
+      period_end { Date.current.end_of_month }
+      target_date { Date.current.end_of_month }
+    end
+
+    trait :rolled_over do
+      status { "rolled_over" }
+      recurring { true }
+      period_start { 1.month.ago.beginning_of_month }
+      period_end { 1.month.ago.end_of_month }
+      target_date { 1.month.ago.end_of_month }
+    end
+
+    trait :with_parent do
+      association :parent_goal, factory: :goal
+    end
   end
 end

--- a/spec/jobs/process_goal_rollovers_job_spec.rb
+++ b/spec/jobs/process_goal_rollovers_job_spec.rb
@@ -1,0 +1,56 @@
+require 'rails_helper'
+
+RSpec.describe ProcessGoalRolloversJob, type: :job do
+  let(:user) { create(:user) }
+  let(:other_user) { create(:user) }
+
+  describe "#perform" do
+    it "calls rollover! on each goal pending rollover" do
+      goal = create(:goal, :recurring, user: user,
+                    period_end: 1.day.ago, status: "active")
+
+      expect { described_class.perform_now }
+        .to change { Goal.count }.by(1)
+        .and change { goal.reload.status }.to("rolled_over")
+    end
+
+    it "creates a new active cycle for each rolled-over goal" do
+      period_end = 1.day.ago.to_date
+      create(:goal, :recurring, user: user, period_end: period_end, status: "active")
+
+      described_class.perform_now
+
+      new_cycle = Goal.last
+      expect(new_cycle.status).to eq("active")
+      expect(new_cycle.current_amount).to eq(0.0)
+      expect(new_cycle.period_start).to eq(period_end.next_month.beginning_of_month)
+    end
+
+    it "does not rollover goals from other users inadvertently" do
+      create(:goal, :recurring, user: user, period_end: 1.day.ago, status: "active")
+      create(:goal, :recurring, user: other_user, period_end: 1.day.ago, status: "active")
+
+      expect { described_class.perform_now }
+        .to change { Goal.count }.by(2)
+    end
+
+    it "does not rollover non-recurring goals" do
+      create(:goal, user: user, recurring: false, period_end: 1.day.ago, status: "active")
+
+      expect { described_class.perform_now }.not_to change { Goal.count }
+    end
+
+    it "does not rollover goals with future period_end" do
+      create(:goal, :recurring, user: user, period_end: 1.month.from_now, status: "active")
+
+      expect { described_class.perform_now }.not_to change { Goal.count }
+    end
+
+    it "is idempotent — does not re-rollover already rolled-over goals" do
+      goal = build(:goal, :rolled_over, user: user, period_end: 1.day.ago)
+      goal.save!(validate: false)
+
+      expect { described_class.perform_now }.not_to change { Goal.count }
+    end
+  end
+end

--- a/spec/models/goal_spec.rb
+++ b/spec/models/goal_spec.rb
@@ -46,6 +46,35 @@ RSpec.describe Goal, type: :model do
         expect(goal.completed?).to be true
       end
     end
+
+    describe "rolled_over status" do
+      let(:goal) do
+        g = build(:goal, :rolled_over, user: user, current_amount: 3000, target_amount: 10000)
+        g.save!(validate: false)
+        g
+      end
+
+      it "#completed? returns false when amounts don't reach target" do
+        expect(goal.completed?).to be false
+      end
+
+      it "#overdue? returns false" do
+        expect(goal.overdue?).to be false
+      end
+
+      it "#due_soon? returns false" do
+        expect(goal.due_soon?).to be false
+      end
+
+      it "#rollover! returns false" do
+        expect(goal.rollover!).to be false
+      end
+
+      it "update_progress does not transition to completed" do
+        goal.update_progress(goal.target_amount)
+        expect(goal.reload.status).to eq("rolled_over")
+      end
+    end
   end
 
   describe "useful scopes" do

--- a/spec/models/goal_spec.rb
+++ b/spec/models/goal_spec.rb
@@ -67,6 +67,88 @@ RSpec.describe Goal, type: :model do
     end
   end
 
+  describe "recurring goals" do
+    describe "#rollover!" do
+      it "creates a new goal for the next month" do
+        goal = create(:goal, :recurring, user: user)
+        next_cycle = goal.rollover!
+
+        expect(next_cycle).to be_persisted
+        expect(next_cycle.period_start).to eq(goal.period_end.next_month.beginning_of_month)
+        expect(next_cycle.period_end).to eq(next_cycle.period_start.end_of_month)
+        expect(next_cycle.current_amount).to eq(0.0)
+        expect(next_cycle.recurring).to be true
+        expect(next_cycle.user_id).to eq(goal.user_id)
+      end
+
+      it "marks the current goal as rolled_over" do
+        goal = create(:goal, :recurring, user: user)
+        goal.rollover!
+
+        expect(goal.reload.status).to eq("rolled_over")
+      end
+
+      it "sets parent_goal_id pointing to the root ancestor" do
+        root = create(:goal, :recurring, user: user)
+        cycle1 = root.rollover!
+        cycle2 = cycle1.rollover!
+
+        expect(cycle1.parent_goal_id).to eq(root.id)
+        expect(cycle2.parent_goal_id).to eq(root.id)
+      end
+
+      it "returns false for non-recurring goals" do
+        goal = create(:goal, user: user, recurring: false)
+        expect(goal.rollover!).to be false
+      end
+
+      it "returns false when goal is not active" do
+        goal = create(:goal, :recurring, :paused, user: user)
+        expect(goal.rollover!).to be false
+      end
+    end
+
+    describe ".pending_rollover" do
+      it "returns recurring active goals with period_end in the past" do
+        past_goal = create(:goal, :recurring, user: user,
+                           period_end: 1.day.ago, status: "active")
+        create(:goal, :recurring, user: user, status: "active")
+        create(:goal, :recurring, user: user, period_end: 1.day.ago, status: "paused")
+
+        expect(Goal.pending_rollover).to contain_exactly(past_goal)
+      end
+    end
+
+    describe "before_create callback" do
+      it "sets period_start and period_end from target_date when recurring" do
+        target = Date.new(2026, 6, 15)
+        goal = create(:goal, user: user, recurring: true,
+                      target_date: target, period_start: nil, period_end: nil)
+
+        expect(goal.period_start).to eq(Date.new(2026, 6, 1))
+        expect(goal.period_end).to eq(Date.new(2026, 6, 30))
+      end
+
+      it "does not set period dates for non-recurring goals" do
+        goal = create(:goal, user: user, recurring: false,
+                      target_date: 1.year.from_now, period_start: nil, period_end: nil)
+
+        expect(goal.period_start).to be_nil
+        expect(goal.period_end).to be_nil
+      end
+    end
+
+    describe "associations" do
+      it "links child goals to parent" do
+        parent = create(:goal, :recurring, user: user)
+        child = create(:goal, :recurring, user: user, parent_goal_id: parent.id)
+
+        expect(parent.child_goals).to include(child)
+        expect(child.parent_goal).to eq(parent)
+      end
+    end
+  end
+
   describe "goal progress integration" do
     let(:category) { create(:category, user: user) }
     let(:goal) { create(:goal, user: user, category: category, target_amount: 1000, current_amount: 0) }

--- a/spec/requests/goals_recurring_spec.rb
+++ b/spec/requests/goals_recurring_spec.rb
@@ -1,0 +1,73 @@
+require "rails_helper"
+
+RSpec.describe "Goals recurring filtering", type: :request do
+  let(:user) { create(:user) }
+
+  before { sign_in_user(user) }
+
+  describe "GET /goals" do
+    let!(:active_goal) { create(:goal, user: user, title: "Active Savings Goal") }
+    let!(:rolled_over_goal) do
+      g = build(:goal, :rolled_over, user: user, title: "Old Rolled Over Goal")
+      g.save!(validate: false)
+      g
+    end
+
+    it "excludes rolled_over goals by default" do
+      get "/goals"
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(active_goal.title)
+      expect(response.body).not_to include(rolled_over_goal.title)
+    end
+
+    it "shows only rolled_over goals with ?history=true" do
+      get "/goals", params: { history: "true" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(rolled_over_goal.title)
+      expect(response.body).not_to include(active_goal.title)
+    end
+
+    it "ignores status filter when showing history" do
+      get "/goals", params: { history: "true", status: "active" }
+
+      expect(response).to have_http_status(:ok)
+      expect(response.body).to include(rolled_over_goal.title)
+    end
+
+    it "applies status filter normally without history param" do
+      paused_goal = create(:goal, user: user, title: "Paused Goal", status: "paused")
+
+      get "/goals", params: { status: "paused" }
+
+      expect(response.body).to include(paused_goal.title)
+      expect(response.body).not_to include(active_goal.title)
+    end
+  end
+
+  describe "POST /goals with recurring" do
+    let(:category) { create(:category, user: user) }
+
+    it "creates a recurring goal and sets period dates automatically" do
+      target_date = 1.month.from_now.end_of_month.to_date
+
+      post "/goals", params: {
+        goal: {
+          title: "Monthly Savings",
+          goal_type: "savings",
+          target_amount: 500,
+          current_amount: 0,
+          target_date: target_date,
+          recurring: true,
+          category_id: category.id
+        }
+      }
+
+      goal = Goal.last
+      expect(goal.recurring).to be true
+      expect(goal.period_start).to eq(target_date.beginning_of_month)
+      expect(goal.period_end).to eq(target_date.end_of_month)
+    end
+  end
+end


### PR DESCRIPTION
## Resumo

- Metas podem ser marcadas como recorrentes mensais ao criar/editar
- Ao virar o mês, um novo ciclo é criado automaticamente via `ProcessGoalRolloversJob`
- Histórico de ciclos anteriores permanece consultável via `?history=true` no index
- Goals `rolled_over` ficam ocultas por padrão no index e são read-only (sem Edit/Update Progress)

## O que muda

### Model (`Goal`)
- Novos campos: `recurring` (boolean), `parent_goal_id` (FK self-referencial), `period_start`, `period_end`
- Novo status: `rolled_over`
- Método `rollover!`: cria o próximo ciclo e marca o atual como `rolled_over`
- Scopes: `recurring_goals`, `pending_rollover`, `history`
- Callback `before_create`: define `period_start/period_end` automaticamente quando `recurring: true`

### Job + Rake task
- `ProcessGoalRolloversJob`: processa todos os goals pendentes de rollover
- `rake goals:process_rollovers`: trigger externo (cron/Solid Queue)

### Controller
- `recurring` adicionado aos params permitidos
- Index exclui `rolled_over` por padrão; `?history=true` exibe histórico
- Filtro de status ignorado quando exibindo histórico

### Views
- Checkbox "Meta recorrente mensal" no formulário
- Badge "Recorrente" e período no card
- Toggle "Ver histórico / ← Metas ativas" no index
- Seção de histórico de ciclos na página de detalhe
- Botões Edit e Update Progress ocultos para goals `rolled_over`

### i18n
- Chaves novas em `en.yml` e `pt-BR.yml`: `rolled_over`, `recurring`, `period`, `cycle_history`, `view_history`, `view_active`

## Testes

**36 exemplos, 0 falhas**

- Model specs: `rollover!`, `pending_rollover`, `before_create` callback, associações, interação com status `rolled_over`
- Job specs: `ProcessGoalRolloversJob` — rollover correto, isolamento por usuário, idempotência
- Request specs: filtragem default/history, combinação de filtros, criação com `recurring: true`

## Scheduling

Para ativar o rollover automático, agendar via cron:
```
0 1 1 * * cd /app && bundle exec rake goals:process_rollovers
```
Ou via Solid Queue `config/recurring.yml` (Rails 8).

Closes #74